### PR TITLE
Refactor tool payload tagging

### DIFF
--- a/plugin/src/Main.server.luau
+++ b/plugin/src/Main.server.luau
@@ -50,8 +50,12 @@ local function connectWebSocket()
 	client.MessageReceived:Connect(function(message)
 		log("[MCP] Message received")
 
-		local body = HttpService:JSONDecode(message)
-		assert(body and body.id and body.args, "Invalid message received")
+                local body = HttpService:JSONDecode(message)
+                assert(body and body.id and body.args, "Invalid message received")
+                assert(type(body.args) == "table", "Invalid message args payload")
+                assert(type(body.args.tool) == "string", "Missing tool identifier in payload")
+                assert(body.args.params ~= nil, "Missing params in payload")
+                assert(type(body.args.params) == "table", "Invalid params payload")
 
 		local id: string = body.id
 		local responseSent = false

--- a/plugin/src/Tools/InsertModel.luau
+++ b/plugin/src/Tools/InsertModel.luau
@@ -123,16 +123,21 @@ local function insertFromMarketplace(query: string): string
 end
 
 local function handleInsertModel(args: Types.ToolArgs): string?
-	if not args["InsertModel"] then
-		return nil
-	end
+        if args.tool ~= "InsertModel" then
+                return nil
+        end
 
-	local insertModelArgs: Types.InsertModelArgs = args["InsertModel"]
-	if type(insertModelArgs.query) ~= "string" then
-		error("Missing query in InsertModel")
-	end
+        local params = args.params
+        if type(params) ~= "table" then
+                error("Missing params in InsertModel payload")
+        end
 
-	return insertFromMarketplace(insertModelArgs.query)
+        local query = params.query
+        if type(query) ~= "string" then
+                error("Missing query in InsertModel")
+        end
+
+        return insertFromMarketplace(query)
 end
 
 return handleInsertModel :: Types.ToolFunction

--- a/plugin/src/Tools/RunCode.luau
+++ b/plugin/src/Tools/RunCode.luau
@@ -118,16 +118,21 @@ local function runCodeWithOutput(command: string): string
 end
 
 local function handleRunCode(args: Types.ToolArgs): string?
-	if not args["RunCode"] then
-		return nil
-	end
+        if args.tool ~= "RunCode" then
+                return nil
+        end
 
-	local runCodeArgs: Types.RunCodeArgs = args["RunCode"]
-	if type(runCodeArgs.command) ~= "string" then
-		error("Missing command in RunCode")
-	end
+        local params = args.params
+        if type(params) ~= "table" then
+                error("Missing params in RunCode payload")
+        end
 
-	return runCodeWithOutput(runCodeArgs.command)
+        local command = params.command
+        if type(command) ~= "string" then
+                error("Missing command in RunCode")
+        end
+
+        return runCodeWithOutput(command)
 end
 
 return handleRunCode :: Types.ToolFunction

--- a/plugin/src/Types.luau
+++ b/plugin/src/Types.luau
@@ -1,12 +1,25 @@
 export type InsertModelArgs = {
-	query: string,
+        query: string,
 }
 
 export type RunCodeArgs = {
-	command: string,
+        command: string,
 }
 
-export type ToolArgs = { InsertModel: InsertModelArgs } | { RunCode: RunCodeArgs }
+export type ToolArgs = {
+        tool: string,
+        params: any,
+}
+
+export type InsertModelToolArgs = {
+        tool: "InsertModel",
+        params: InsertModelArgs,
+}
+
+export type RunCodeToolArgs = {
+        tool: "RunCode",
+        params: RunCodeArgs,
+}
 
 export type ToolFunction = (ToolArgs) -> string?
 

--- a/src/rbx_studio_server.rs
+++ b/src/rbx_studio_server.rs
@@ -102,6 +102,7 @@ struct InsertModel {
 }
 
 #[derive(Debug, Deserialize, Serialize, schemars::JsonSchema, Clone)]
+#[serde(tag = "tool", content = "params")]
 enum ToolArgumentValues {
     RunCode(RunCode),
     InsertModel(InsertModel),


### PR DESCRIPTION
## Summary
- switch tool argument payloads to a serde-tagged enum so new variants keep a stable envelope
- update the Roblox Studio plugin types and handlers to read `{ tool, params }` payloads
- add defensive validation around incoming tool messages before dispatching to modules

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_b_68e54a30b28c832fb1265950362fd22c