### PR TITLE
Add InspectEnvironment MCP tool for read-only insights

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ To make sure everything is set up correctly, follow these steps:
    which you can also verify in the console output.
 1. Verify that Claude Desktop is correctly configured by clicking on the hammer icon for MCP tools
    beneath the text field where you enter prompts. This should open a window with the list of
-   available Roblox Studio tools (`insert_model` and `run_code`).
+   available Roblox Studio tools (`insert_model`, `inspect_environment`, and `run_code`).
 
 **Note**: You can fix common issues with setup by restarting Studio and Claude Desktop. Claude
 sometimes is hidden in the system tray, so ensure you've exited it completely.
@@ -99,3 +99,23 @@ sometimes is hidden in the system tray, so ensure you've exited it completely.
 1. Type a prompt in Claude Desktop and accept any permissions to communicate with Studio.
 1. Verify that the intended action is performed in Studio by checking the console, inspecting the
    data model in Explorer, or visually confirming the desired changes occurred in your place.
+
+## Available MCP tools
+
+Claude Desktop and Cursor expose the following Roblox Studio tooling through this server:
+
+- **`run_code`** – Execute Luau snippets directly in Studio and stream any printed output or return
+  values back to the client.
+- **`insert_model`** – Search for a marketplace model by name, insert the best match into the
+  workspace, and report the name of the created instance.
+- **`inspect_environment`** – Collect read-only information about the current Studio session. The
+  tool accepts an object with optional sections that let you tailor the response:
+  - `selection`: Controls which properties of selected instances are reported. `includeNames`,
+    `includeClassNames`, and `includeFullNames` default to `true` and determine whether those fields
+    are present in the response.
+  - `camera`: Describes what camera details to emit. Toggle `includeCFrame`, `includeFocus`, and
+    `includeFieldOfView` (all default `true`) to adjust the payload.
+  - `services`: Allows you to inspect key services without mutating the place. Provide
+    `services = { "Workspace", "Players", ... }` to customize the list and set `includeCounts`
+    (default `true`) to gather descendant totals. The plugin serializes the results with
+    `HttpService:JSONEncode`, so responses are safe to parse directly in Claude/Cursor prompts.

--- a/plugin/src/Main.server.luau
+++ b/plugin/src/Main.server.luau
@@ -50,13 +50,14 @@ local function connectWebSocket()
 	client.MessageReceived:Connect(function(message)
 		log("[MCP] Message received")
 
-                local body = HttpService:JSONDecode(message)
-                assert(body and body.id and body.args, "Invalid message received")
-                assert(type(body.args) == "table", "Invalid message args payload")
-                assert(type(body.args.tool) == "string", "Missing tool identifier in payload")
-                assert(body.args.params ~= nil, "Missing params in payload")
-                assert(type(body.args.params) == "table", "Invalid params payload")
+		local body = HttpService:JSONDecode(message)
+		assert(body and body.id and body.args, "Invalid message received")
+		assert(type(body.args) == "table", "Invalid message args payload")
+		assert(type(body.args.tool) == "string", "Missing tool identifier in payload")
+		assert(body.args.params ~= nil, "Missing params in payload")
+		assert(type(body.args.params) == "table", "Invalid params payload")
 
+		local args: Types.ToolArgs = body.args
 		local id: string = body.id
 		local responseSent = false
 		local function sendResponseOnce(response: string)
@@ -67,17 +68,25 @@ local function connectWebSocket()
 					id = id,
 					response = response,
 				})
+				if args.tool == "InspectEnvironment" then
+					log("[MCP] Inspection response sent to MCP client")
+				end
 			end
 		end
 
-		local args: Types.ToolArgs = body.args
-		local recording = ChangeHistoryService:TryBeginRecording("StudioMCP")
+		local shouldRecordHistory = args.tool ~= "InspectEnvironment"
+		local recording = if shouldRecordHistory
+			then ChangeHistoryService:TryBeginRecording("StudioMCP")
+			else nil
 
 		for _, tool in tools do
 			local success, response = pcall(tool, args)
 
 			if success and response then
 				sendResponseOnce(response)
+				if args.tool == "InspectEnvironment" then
+					log("[MCP] Inspection response returned")
+				end
 			elseif not success then
 				sendResponseOnce("Error handling request: " .. tostring(response))
 			end

--- a/plugin/src/Tools/InspectEnvironment.luau
+++ b/plugin/src/Tools/InspectEnvironment.luau
@@ -1,0 +1,164 @@
+local Main = script:FindFirstAncestor("MCPStudioPlugin")
+local Types = require(Main.Types)
+
+local HttpService = game:GetService("HttpService")
+local SelectionService = game:GetService("Selection")
+local Workspace = game:GetService("Workspace")
+
+local DEFAULT_SERVICES = {
+	"Workspace",
+	"Players",
+	"Lighting",
+	"ReplicatedStorage",
+	"ServerScriptService",
+	"StarterGui",
+}
+
+local function boolDefault(value: any, fallback: boolean): boolean
+	if type(value) == "boolean" then
+		return value
+	end
+	return fallback
+end
+
+local function vectorToTable(vector: Vector3)
+	return {
+		x = vector.X,
+		y = vector.Y,
+		z = vector.Z,
+	}
+end
+
+local function cframeToTable(cf: CFrame)
+	return {
+		position = vectorToTable(cf.Position),
+		lookVector = vectorToTable(cf.LookVector),
+		upVector = vectorToTable(cf.UpVector),
+		rightVector = vectorToTable(cf.RightVector),
+	}
+end
+
+local function gatherSelection(scope: Types.InspectSelectionScope?): { [string]: any }
+	local resolvedScope: Types.InspectSelectionScope = (scope or {}) :: Types.InspectSelectionScope
+
+	local includeNames = boolDefault(resolvedScope.includeNames, true)
+	local includeClassNames = boolDefault(resolvedScope.includeClassNames, true)
+	local includeFullNames = boolDefault(resolvedScope.includeFullNames, true)
+
+	local items = {}
+	for _, instance in SelectionService:Get() do
+		local entry = {}
+		if includeNames then
+			entry.name = instance.Name
+		end
+		if includeClassNames then
+			entry.className = instance.ClassName
+		end
+		if includeFullNames then
+			entry.fullName = instance:GetFullName()
+		end
+
+		table.insert(items, entry)
+	end
+
+	return {
+		total = #items,
+		items = items,
+	}
+end
+
+local function gatherCamera(scope: Types.InspectCameraScope?): { [string]: any }
+	local resolvedScope: Types.InspectCameraScope = (scope or {}) :: Types.InspectCameraScope
+
+	local camera = Workspace.CurrentCamera
+	if not camera then
+		return {
+			available = false,
+			reason = "CurrentCamera is nil",
+		}
+	end
+
+	local includeCFrame = boolDefault(resolvedScope.includeCFrame, true)
+	local includeFocus = boolDefault(resolvedScope.includeFocus, true)
+	local includeFieldOfView = boolDefault(resolvedScope.includeFieldOfView, true)
+
+	local data = {
+		available = true,
+	}
+
+	if includeCFrame then
+		data.cframe = cframeToTable(camera.CFrame)
+	end
+
+	if includeFocus then
+		data.focus = cframeToTable(camera.Focus)
+	end
+
+	if includeFieldOfView then
+		data.fieldOfView = camera.FieldOfView
+	end
+
+	return data
+end
+
+local function gatherServiceCounts(scope: Types.InspectServicesScope?): { [string]: any }
+	local resolvedScope: Types.InspectServicesScope = (scope or {}) :: Types.InspectServicesScope
+
+	local includeCounts = boolDefault(resolvedScope.includeCounts, true)
+	local serviceNames = resolvedScope.services or DEFAULT_SERVICES
+
+	local serviceDetails = {}
+	for _, serviceName in serviceNames do
+		local success, service = pcall(game.GetService, game, serviceName)
+		if success and service then
+			serviceDetails[serviceName] = if includeCounts
+				then #service:GetDescendants()
+				else "available"
+		else
+			serviceDetails[serviceName] = "unavailable"
+		end
+	end
+
+	return {
+		includeCounts = includeCounts,
+		services = serviceDetails,
+	}
+end
+
+local function handleInspectEnvironment(args: Types.ToolArgs): string?
+	if args.tool ~= "InspectEnvironment" then
+		return nil
+	end
+
+	local params = args.params
+	if type(params) ~= "table" then
+		error("Missing params in InspectEnvironment payload")
+	end
+
+	if params.selection ~= nil and type(params.selection) ~= "table" then
+		error("Invalid selection scope in InspectEnvironment params")
+	end
+	if params.camera ~= nil and type(params.camera) ~= "table" then
+		error("Invalid camera scope in InspectEnvironment params")
+	end
+	if params.services ~= nil and type(params.services) ~= "table" then
+		error("Invalid services scope in InspectEnvironment params")
+	end
+
+	local selection = gatherSelection(params.selection)
+	local camera = gatherCamera(params.camera)
+	local services = gatherServiceCounts(params.services)
+
+	local payload = {
+		selection = selection,
+		camera = camera,
+		services = services,
+		metadata = {
+			generatedAt = DateTime.now():ToIsoDateTime(),
+		},
+	}
+
+	return HttpService:JSONEncode(payload)
+end
+
+return handleInspectEnvironment :: Types.ToolFunction

--- a/plugin/src/Types.luau
+++ b/plugin/src/Types.luau
@@ -6,6 +6,29 @@ export type RunCodeArgs = {
         command: string,
 }
 
+export type InspectSelectionScope = {
+        includeNames: boolean?,
+        includeClassNames: boolean?,
+        includeFullNames: boolean?,
+}
+
+export type InspectCameraScope = {
+        includeCFrame: boolean?,
+        includeFocus: boolean?,
+        includeFieldOfView: boolean?,
+}
+
+export type InspectServicesScope = {
+        includeCounts: boolean?,
+        services: { string }?,
+}
+
+export type InspectEnvironmentArgs = {
+        selection: InspectSelectionScope?,
+        camera: InspectCameraScope?,
+        services: InspectServicesScope?,
+}
+
 export type ToolArgs = {
         tool: string,
         params: any,
@@ -19,6 +42,11 @@ export type InsertModelToolArgs = {
 export type RunCodeToolArgs = {
         tool: "RunCode",
         params: RunCodeArgs,
+}
+
+export type InspectEnvironmentToolArgs = {
+        tool: "InspectEnvironment",
+        params: InspectEnvironmentArgs,
 }
 
 export type ToolFunction = (ToolArgs) -> string?


### PR DESCRIPTION
## Summary
- add an InspectEnvironment tool variant to the server API with schema support for selection, camera, and service scopes
- implement the InspectEnvironment Luau handler that collects selection details, camera data, and service statistics and serializes them to JSON
- log inspection responses, skip change-history recording for read-only runs, and document the new tool in the README

## Testing
- cargo check

------
https://chatgpt.com/codex/tasks/task_b_68e54f6f17c8832fa9a1ac30452035ae