### PR TITLE
Add diagnostics tool for logs and performance metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,10 @@ Claude Desktop and Cursor expose the following Roblox Studio tooling through thi
   files, and publish packages without leaving Claude or Cursor. Each operation reports structured
   status including resolved instance paths, collision handling decisions, placement adjustments, and
   optional package metadata.
+- **`diagnostics_and_metrics`** – Gather troubleshooting data from Studio in a single response. The
+  tool can stream recent error and warning logs in timestamped chunks, capture memory usage
+  (including DeveloperMemoryTag breakdowns), summarise TaskScheduler and service health, and
+  optionally return a MicroProfiler snapshot when you have diagnostics permissions enabled.
 
 > **Safety notice:** Starting a play session or running the test harness will execute scripts and
 > may mutate workspace state that has not been saved. Ensure critical changes are committed to
@@ -157,6 +161,27 @@ Use apply_instance_operations to:
 2. Update Workspace/SetPiece/SpotlightCube so its Color is (1, 0.8, 0.6) and Transparency is 0.25.
 3. Delete Workspace/Temporary/DebugFolder.
 ```
+
+### Requesting diagnostics
+
+The `diagnostics_and_metrics` tool accepts a payload that lets you tailor what Studio collects. For
+example:
+
+```
+{
+  "logs": { "maxEntries": 120, "chunkSize": 40 },
+  "includeMemoryStats": true,
+  "includeTaskScheduler": true,
+  "includeMicroProfiler": false,
+  "serviceSelection": { "services": ["Workspace", "Players"] }
+}
+```
+
+Set `includeMicroProfiler` to `true` only after enabling the MicroProfiler in Studio (View →
+MicroProfiler or File → Studio Settings → Diagnostics → Allow MicroProfiler). Roblox requires that
+permission to be granted per-user; without it the tool will return a note explaining that the dump
+is unavailable. Error and warning logs are chunked for long sessions so MCP clients can page through
+them without hitting token limits.
 
 The MCP client will translate that request into JSON similar to:
 

--- a/plugin/src/Tools/DiagnosticsAndMetrics.luau
+++ b/plugin/src/Tools/DiagnosticsAndMetrics.luau
@@ -1,0 +1,396 @@
+local Main = script:FindFirstAncestor("MCPStudioPlugin")
+local Types = require(Main.Types)
+
+local HttpService = game:GetService("HttpService")
+local LogService = game:GetService("LogService")
+local StatsService = game:GetService("Stats")
+
+local DEFAULT_SERVICES = {
+        "Workspace",
+        "Players",
+        "Lighting",
+        "ReplicatedStorage",
+        "ServerScriptService",
+}
+
+local MEMORY_TAG_OVERRIDES: { [string]: string } = {
+        ServerScriptService = "Script",
+        StarterGui = "Gui",
+        StarterPlayer = "StarterPlayer",
+        StarterPack = "StarterPack",
+}
+
+local function boolDefault(value: any, fallback: boolean): boolean
+        if type(value) == "boolean" then
+                return value
+        end
+        return fallback
+end
+
+local function numberDefault(value: any, fallback: number, minValue: number?): number
+        if type(value) == "number" and value == value then
+                if minValue and value < minValue then
+                        return fallback
+                end
+                return value
+        end
+        return fallback
+end
+
+local function findEnumByName(enumType: Enum, name: string)
+        for _, item in enumType:GetEnumItems() do
+                if item.Name == name then
+                        return item
+                end
+        end
+        return nil
+end
+
+local function isoTimestampFromEntry(entry: { [string]: any }): string?
+        local candidate = entry.timestamp or entry.time or entry.Time
+        if typeof(candidate) == "DateTime" then
+                return candidate:ToIsoDateTime()
+        elseif type(candidate) == "number" then
+                local ok, value = pcall(DateTime.fromUnixTimestamp, candidate)
+                if ok and typeof(value) == "DateTime" then
+                        return value:ToIsoDateTime()
+                end
+        elseif type(candidate) == "string" then
+                return candidate
+        end
+        return nil
+end
+
+local function severityFromMessageType(messageType: Enum.MessageType?): string
+        if messageType == Enum.MessageType.MessageError then
+                return "error"
+        elseif messageType == Enum.MessageType.MessageWarning then
+                return "warning"
+        elseif messageType == Enum.MessageType.MessageInfo then
+                return "info"
+        elseif messageType == Enum.MessageType.MessageOutput then
+                return "info"
+        end
+        return "info"
+end
+
+local function gatherLogHistory(options: Types.DiagnosticsLogOptions?): { [string]: any }?
+        local resolved: Types.DiagnosticsLogOptions = (options or {}) :: Types.DiagnosticsLogOptions
+
+        local includeErrors = boolDefault(resolved.includeErrors, true)
+        local includeWarnings = boolDefault(resolved.includeWarnings, true)
+        local includeInfo = boolDefault(resolved.includeInfo, false)
+
+        local maxEntries = resolved.maxEntries
+        if type(maxEntries) ~= "number" or maxEntries <= 0 then
+                maxEntries = nil
+        end
+
+        local chunkSize = numberDefault(resolved.chunkSize, 100, 1)
+
+        local ok, history = pcall(LogService.GetLogHistory, LogService)
+        if not ok or type(history) ~= "table" then
+                return {
+                        available = false,
+                        reason = if ok
+                                then "LogService returned unexpected data"
+                                else tostring(history),
+                }
+        end
+
+        local filtered = {}
+        for _, entry in history do
+                if type(entry) == "table" then
+                        local severity = severityFromMessageType(entry.messageType)
+                        local shouldInclude = if severity == "error"
+                                then includeErrors
+                                elseif severity == "warning"
+                                then includeWarnings
+                                else includeInfo
+                        if shouldInclude then
+                                table.insert(filtered, {
+                                        message = tostring(entry.message),
+                                        severity = severity,
+                                        timestamp = isoTimestampFromEntry(entry),
+                                        source = entry.source,
+                                })
+                        end
+                end
+        end
+
+        local truncated = false
+        if maxEntries and #filtered > maxEntries then
+                truncated = true
+                local startIndex = math.max(#filtered - maxEntries + 1, 1)
+                local trimmed = {}
+                for index = startIndex, #filtered do
+                        table.insert(trimmed, filtered[index])
+                end
+                filtered = trimmed
+        end
+
+        local chunks = {}
+        local index = 1
+        local chunkIndex = 1
+        while index <= #filtered do
+                local chunk = {}
+                local upper = math.min(index + chunkSize - 1, #filtered)
+                for i = index, upper do
+                        table.insert(chunk, filtered[i])
+                end
+                table.insert(chunks, {
+                        index = chunkIndex,
+                        entries = chunk,
+                })
+                index = upper + 1
+                chunkIndex += 1
+        end
+
+        return {
+                        available = true,
+                        totalEntries = #filtered,
+                        chunkSize = chunkSize,
+                        truncated = truncated,
+                        chunks = chunks,
+        }
+end
+
+local function gatherMemoryStats(includeMemory: boolean?): { [string]: any }?
+        if not boolDefault(includeMemory, true) then
+                return nil
+        end
+
+        local data: { [string]: any } = {
+                available = true,
+        }
+
+        local okTotal, totalMemory = pcall(StatsService.GetTotalMemoryUsageMb, StatsService)
+        if okTotal then
+                data.totalMemoryMb = totalMemory
+        end
+
+        local tagNames = {
+                "Workspace",
+                "Instances",
+                "PhysicsParts",
+                "Script",
+                "Gui",
+                "Terrain",
+                "Navigation",
+                "Particles",
+                "Animation",
+                "Sounds",
+                "Network",
+                "LuaHeap",
+        }
+
+        local tagBreakdown = {}
+        for _, name in tagNames do
+                local tag = findEnumByName(Enum.DeveloperMemoryTag, name)
+                if tag then
+                        local okValue, value = pcall(StatsService.GetMemoryUsageMbForTag, StatsService, tag)
+                        if okValue then
+                                tagBreakdown[name] = value
+                        end
+                end
+        end
+        if next(tagBreakdown) ~= nil then
+                data.tags = tagBreakdown
+        end
+
+        return data
+end
+
+local function findMemoryTagForService(serviceName: string)
+        local candidates = { serviceName }
+        local override = MEMORY_TAG_OVERRIDES[serviceName]
+        if override then
+                table.insert(candidates, override)
+        end
+        for _, candidate in candidates do
+                local tag = findEnumByName(Enum.DeveloperMemoryTag, candidate)
+                if tag then
+                        return tag
+                end
+        end
+        return nil
+end
+
+local function gatherServiceMetrics(selection: Types.DiagnosticsServiceSelection?): { [string]: any }?
+        local resolved: Types.DiagnosticsServiceSelection = (selection or {}) :: Types.DiagnosticsServiceSelection
+        local services = resolved.services
+        if type(services) ~= "table" or #services == 0 then
+                services = DEFAULT_SERVICES
+        end
+
+        local includeCounts = boolDefault(resolved.includeDescendantCounts, true)
+        local includeMemoryTags = boolDefault(resolved.includeMemoryTags, true)
+
+        local results: { [string]: any } = {}
+        for _, serviceName in services do
+                if type(serviceName) == "string" then
+                        local entry = {
+                                name = serviceName,
+                        }
+
+                        local success, serviceOrError = pcall(game.GetService, game, serviceName)
+                        if success and serviceOrError then
+                                entry.available = true
+                                if includeCounts then
+                                        local okCount, descendantCount = pcall(function()
+                                                return #serviceOrError:GetDescendants()
+                                        end)
+                                        if okCount then
+                                                entry.descendantCount = descendantCount
+                                        end
+                                end
+
+                                if includeMemoryTags then
+                                        local tag = findMemoryTagForService(serviceName)
+                                        if tag then
+                                                local okUsage, usage = pcall(StatsService.GetMemoryUsageMbForTag, StatsService, tag)
+                                                if okUsage then
+                                                        entry.memoryUsageMb = usage
+                                                end
+                                        end
+                                end
+                        else
+                                entry.available = false
+                                entry.reason = tostring(serviceOrError)
+                        end
+
+                        results[serviceName] = entry
+                end
+        end
+
+        return {
+                includeDescendantCounts = includeCounts,
+                includeMemoryTags = includeMemoryTags,
+                services = results,
+        }
+end
+
+local function gatherMicroProfiler(includeMicroProfiler: boolean?): { [string]: any }?
+        if not boolDefault(includeMicroProfiler, false) then
+                        return nil
+        end
+
+        local okDump, dump = pcall(LogService.GetMicroProfilerDump, LogService)
+        if not okDump then
+                        return {
+                                available = false,
+                                reason = tostring(dump),
+                        }
+        end
+
+        if type(dump) == "string" then
+                        return {
+                                available = true,
+                                snapshot = dump,
+                        }
+        end
+
+        return {
+                        available = false,
+                        reason = "Microprofiler dump unavailable or unsupported",
+        }
+end
+
+local function gatherTaskScheduler(includeScheduler: boolean?): { [string]: any }?
+        if not boolDefault(includeScheduler, true) then
+                return nil
+        end
+
+        local success, scheduler = pcall(game.GetService, game, "TaskScheduler")
+        if not success or not scheduler then
+                return {
+                        available = false,
+                        reason = tostring(scheduler),
+                }
+        end
+
+        local data: { [string]: any } = {
+                available = true,
+        }
+
+        local okState, state = pcall(function()
+                if scheduler.GetState then
+                        return scheduler:GetState()
+                elseif scheduler.GetSchedulerState then
+                        return scheduler:GetSchedulerState()
+                end
+                return nil
+        end)
+        if okState and state ~= nil then
+                data.state = state
+        end
+
+        local okStats, stats = pcall(function()
+                if scheduler.GetSchedulerStats then
+                        return scheduler:GetSchedulerStats()
+                elseif scheduler.GetThreadStats then
+                        return scheduler:GetThreadStats()
+                end
+                return nil
+        end)
+        if okStats and type(stats) == "table" then
+                data.stats = stats
+        end
+
+        if data.state == nil and data.stats == nil then
+                data.available = false
+                data.reason = "TaskScheduler metrics not exposed in this environment"
+        end
+
+        return data
+end
+
+local function handleDiagnosticsAndMetrics(args: Types.ToolArgs): string?
+        if args.tool ~= "DiagnosticsAndMetrics" then
+                return nil
+        end
+
+        local params = args.params :: Types.DiagnosticsAndMetricsArgs
+        if type(params) ~= "table" then
+                error("Missing params in DiagnosticsAndMetrics payload")
+        end
+
+        if params.logs ~= nil and type(params.logs) ~= "table" then
+                error("Invalid logs configuration in DiagnosticsAndMetrics params")
+        end
+        if params.serviceSelection ~= nil and type(params.serviceSelection) ~= "table" then
+                error("Invalid serviceSelection in DiagnosticsAndMetrics params")
+        end
+
+        local logSection = gatherLogHistory(params.logs)
+        local memorySection = gatherMemoryStats(params.includeMemoryStats)
+        local microProfilerSection = gatherMicroProfiler(params.includeMicroProfiler)
+        local servicesSection = gatherServiceMetrics(params.serviceSelection)
+        local schedulerSection = gatherTaskScheduler(params.includeTaskScheduler)
+
+        local payload: { [string]: any } = {
+                metadata = {
+                        generatedAt = DateTime.now():ToIsoDateTime(),
+                },
+        }
+
+        if logSection then
+                payload.logs = logSection
+        end
+        if memorySection then
+                payload.memory = memorySection
+        end
+        if microProfilerSection then
+                payload.microProfiler = microProfilerSection
+        end
+        if servicesSection then
+                payload.services = servicesSection
+        end
+        if schedulerSection then
+                payload.taskScheduler = schedulerSection
+        end
+
+        return HttpService:JSONEncode(payload)
+end
+
+return handleDiagnosticsAndMetrics :: Types.ToolFunction

--- a/plugin/src/Types.luau
+++ b/plugin/src/Types.luau
@@ -29,6 +29,28 @@ export type InspectEnvironmentArgs = {
         services: InspectServicesScope?,
 }
 
+export type DiagnosticsLogOptions = {
+        includeErrors: boolean?,
+        includeWarnings: boolean?,
+        includeInfo: boolean?,
+        maxEntries: number?,
+        chunkSize: number?,
+}
+
+export type DiagnosticsServiceSelection = {
+        services: { string }?,
+        includeDescendantCounts: boolean?,
+        includeMemoryTags: boolean?,
+}
+
+export type DiagnosticsAndMetricsArgs = {
+        logs: DiagnosticsLogOptions?,
+        includeMicroProfiler: boolean?,
+        includeMemoryStats: boolean?,
+        includeTaskScheduler: boolean?,
+        serviceSelection: DiagnosticsServiceSelection?,
+}
+
 export type InstancePath = { string }
 
 export type InstanceOperationAction = "create" | "update" | "delete"
@@ -147,6 +169,11 @@ export type RunCodeToolArgs = {
 export type InspectEnvironmentToolArgs = {
         tool: "InspectEnvironment",
         params: InspectEnvironmentArgs,
+}
+
+export type DiagnosticsAndMetricsToolArgs = {
+        tool: "DiagnosticsAndMetrics",
+        params: DiagnosticsAndMetricsArgs,
 }
 
 export type ApplyInstanceOperationsToolArgs = {


### PR DESCRIPTION
## Summary
- add diagnostics_and_metrics tool schema and registration for the MCP server
- implement the Studio plugin diagnostics collector covering logs, memory, services, scheduler, and microprofiler data
- update README with usage guidance and microprofiler permission requirements

## Testing
- cargo check

------
https://chatgpt.com/codex/tasks/task_b_68e5cd8656b8832f948bb991234b6e59