### PR TITLE
Improve inspect environment typings and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,32 @@ Claude Desktop and Cursor expose the following Roblox Studio tooling through thi
 > source control or saved locally before invoking the play or test tools, and avoid relying on
 > temporary state that might be reset when Studio reloads the environment.
 
+### Inspecting the Studio environment
+
+You can ask Claude or Cursor to sample the current environment by calling:
+
+```json
+{
+  "tool": "InspectEnvironment",
+  "params": {
+    "selection": { "includeFullNames": false },
+    "camera": { "includeFocus": false },
+    "services": { "services": ["Workspace", "Players"], "includeCounts": true }
+  }
+}
+```
+
+The response is JSON with the following sections:
+
+- `selection`: Total selected instances plus per-item `name`, `className`, and `fullName` (opt-in).
+- `camera`: Indicates whether `Workspace.CurrentCamera` exists, and includes the CFrame/focus
+  vectors and field of view when requested.
+- `services`: Reports requested service availability, optionally including descendant counts.
+- `metadata.generatedAt`: Timestamp (ISO 8601) that the plugin recorded for traceability.
+
+These payloads are ideal for prompts such as "summarise the selected models" or "describe the camera
+setup" without mutating the place or creating ChangeHistory checkpoints.
+
 ### Terrain authoring workflow
 
 `terrain_operations` requests look like the following:

--- a/plugin/src/Tools/InspectEnvironment.luau
+++ b/plugin/src/Tools/InspectEnvironment.luau
@@ -21,36 +21,36 @@ local function boolDefault(value: any, fallback: boolean): boolean
 	return fallback
 end
 
-local function vectorToTable(vector: Vector3)
-	return {
-		x = vector.X,
-		y = vector.Y,
-		z = vector.Z,
-	}
+local function vectorToTable(vector: Vector3): Types.Vector3Record
+        return {
+                x = vector.X,
+                y = vector.Y,
+                z = vector.Z,
+        }
 end
 
-local function cframeToTable(cf: CFrame)
-	return {
-		position = vectorToTable(cf.Position),
-		lookVector = vectorToTable(cf.LookVector),
-		upVector = vectorToTable(cf.UpVector),
-		rightVector = vectorToTable(cf.RightVector),
-	}
+local function cframeToTable(cf: CFrame): Types.InspectCameraFrame
+        return {
+                position = vectorToTable(cf.Position),
+                lookVector = vectorToTable(cf.LookVector),
+                upVector = vectorToTable(cf.UpVector),
+                rightVector = vectorToTable(cf.RightVector),
+        }
 end
 
-local function gatherSelection(scope: Types.InspectSelectionScope?): { [string]: any }
-	local resolvedScope: Types.InspectSelectionScope = (scope or {}) :: Types.InspectSelectionScope
+local function gatherSelection(scope: Types.InspectSelectionScope?): Types.InspectSelectionResult
+        local resolvedScope: Types.InspectSelectionScope = (scope or {}) :: Types.InspectSelectionScope
 
-	local includeNames = boolDefault(resolvedScope.includeNames, true)
-	local includeClassNames = boolDefault(resolvedScope.includeClassNames, true)
-	local includeFullNames = boolDefault(resolvedScope.includeFullNames, true)
+        local includeNames = boolDefault(resolvedScope.includeNames, true)
+        local includeClassNames = boolDefault(resolvedScope.includeClassNames, true)
+        local includeFullNames = boolDefault(resolvedScope.includeFullNames, true)
 
-	local items = {}
-	for _, instance in SelectionService:Get() do
-		local entry = {}
-		if includeNames then
-			entry.name = instance.Name
-		end
+        local items: { Types.InspectSelectionItem } = {}
+        for _, instance in SelectionService:Get() do
+                local entry: Types.InspectSelectionItem = {}
+                if includeNames then
+                        entry.name = instance.Name
+                end
 		if includeClassNames then
 			entry.className = instance.ClassName
 		end
@@ -61,18 +61,18 @@ local function gatherSelection(scope: Types.InspectSelectionScope?): { [string]:
 		table.insert(items, entry)
 	end
 
-	return {
-		total = #items,
-		items = items,
-	}
+        return {
+                total = #items,
+                items = items,
+        }
 end
 
-local function gatherCamera(scope: Types.InspectCameraScope?): { [string]: any }
-	local resolvedScope: Types.InspectCameraScope = (scope or {}) :: Types.InspectCameraScope
+local function gatherCamera(scope: Types.InspectCameraScope?): Types.InspectCameraResult
+        local resolvedScope: Types.InspectCameraScope = (scope or {}) :: Types.InspectCameraScope
 
-	local camera = Workspace.CurrentCamera
-	if not camera then
-		return {
+        local camera = Workspace.CurrentCamera
+        if not camera then
+                return {
 			available = false,
 			reason = "CurrentCamera is nil",
 		}
@@ -82,12 +82,17 @@ local function gatherCamera(scope: Types.InspectCameraScope?): { [string]: any }
 	local includeFocus = boolDefault(resolvedScope.includeFocus, true)
 	local includeFieldOfView = boolDefault(resolvedScope.includeFieldOfView, true)
 
-	local data = {
-		available = true,
-	}
+        local data: {
+                available: true,
+                cframe: Types.InspectCameraFrame?,
+                focus: Types.InspectCameraFrame?,
+                fieldOfView: number?,
+        } = {
+                available = true,
+        }
 
-	if includeCFrame then
-		data.cframe = cframeToTable(camera.CFrame)
+        if includeCFrame then
+                data.cframe = cframeToTable(camera.CFrame)
 	end
 
 	if includeFocus then
@@ -98,21 +103,21 @@ local function gatherCamera(scope: Types.InspectCameraScope?): { [string]: any }
 		data.fieldOfView = camera.FieldOfView
 	end
 
-	return data
+        return data :: Types.InspectCameraResult
 end
 
-local function gatherServiceCounts(scope: Types.InspectServicesScope?): { [string]: any }
-	local resolvedScope: Types.InspectServicesScope = (scope or {}) :: Types.InspectServicesScope
+local function gatherServiceCounts(scope: Types.InspectServicesScope?): Types.InspectServicesResult
+        local resolvedScope: Types.InspectServicesScope = (scope or {}) :: Types.InspectServicesScope
 
-	local includeCounts = boolDefault(resolvedScope.includeCounts, true)
-	local serviceNames = resolvedScope.services or DEFAULT_SERVICES
+        local includeCounts = boolDefault(resolvedScope.includeCounts, true)
+        local serviceNames = resolvedScope.services or DEFAULT_SERVICES
 
-	local serviceDetails = {}
-	for _, serviceName in serviceNames do
-		local success, service = pcall(game.GetService, game, serviceName)
-		if success and service then
-			serviceDetails[serviceName] = if includeCounts
-				then #service:GetDescendants()
+        local serviceDetails: Types.InspectServicesMap = {}
+        for _, serviceName in serviceNames do
+                local success, service = pcall(game.GetService, game, serviceName)
+                if success and service then
+                        serviceDetails[serviceName] = if includeCounts
+                                then #service:GetDescendants()
 				else "available"
 		else
 			serviceDetails[serviceName] = "unavailable"
@@ -145,16 +150,16 @@ local function handleInspectEnvironment(args: Types.ToolArgs): string?
 		error("Invalid services scope in InspectEnvironment params")
 	end
 
-	local selection = gatherSelection(params.selection)
-	local camera = gatherCamera(params.camera)
-	local services = gatherServiceCounts(params.services)
+        local selection = gatherSelection(params.selection)
+        local camera = gatherCamera(params.camera)
+        local services = gatherServiceCounts(params.services)
 
-	local payload = {
-		selection = selection,
-		camera = camera,
-		services = services,
-		metadata = {
-			generatedAt = DateTime.now():ToIsoDateTime(),
+        local payload: Types.InspectEnvironmentResponse = {
+                selection = selection,
+                camera = camera,
+                services = services,
+                metadata = {
+                        generatedAt = DateTime.now():ToIsoDateTime(),
 		},
 	}
 

--- a/plugin/src/Types.luau
+++ b/plugin/src/Types.luau
@@ -29,6 +29,54 @@ export type InspectEnvironmentArgs = {
         services: InspectServicesScope?,
 }
 
+export type InspectSelectionItem = {
+        name: string?,
+        className: string?,
+        fullName: string?,
+}
+
+export type InspectSelectionResult = {
+        total: number,
+        items: { InspectSelectionItem },
+}
+
+export type Vector3Record = { x: number, y: number, z: number }
+
+export type InspectCameraFrame = {
+        position: Vector3Record,
+        lookVector: Vector3Record,
+        upVector: Vector3Record,
+        rightVector: Vector3Record,
+}
+
+export type InspectCameraResult =
+        ({
+                available: true,
+                cframe: InspectCameraFrame?,
+                focus: InspectCameraFrame?,
+                fieldOfView: number?,
+        })
+        | ({
+                available: false,
+                reason: string,
+        })
+
+export type InspectServicesMap = { [string]: number | string }
+
+export type InspectServicesResult = {
+        includeCounts: boolean,
+        services: InspectServicesMap,
+}
+
+export type InspectEnvironmentResponse = {
+        selection: InspectSelectionResult,
+        camera: InspectCameraResult,
+        services: InspectServicesResult,
+        metadata: {
+                generatedAt: string,
+        },
+}
+
 export type DiagnosticsLogOptions = {
         includeErrors: boolean?,
         includeWarnings: boolean?,


### PR DESCRIPTION
## Summary
- add structured Luau type definitions describing InspectEnvironment responses
- update the InspectEnvironment tool to return strongly typed payloads and metadata
- expand README guidance with an example InspectEnvironment request and explanation of the response

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68e5f07d7d5c832f9dd16c80b20465da