### PR TITLE
Add bulk instance operations tooling and documentation

### DIFF
--- a/plugin/src/Tools/ApplyInstanceOperations.luau
+++ b/plugin/src/Tools/ApplyInstanceOperations.luau
@@ -6,6 +6,8 @@ local HttpService = game:GetService("HttpService")
 
 type ApplyInstanceOperation = Types.ApplyInstanceOperation
 type ApplyInstanceOperationsArgs = Types.ApplyInstanceOperationsArgs
+type ApplyInstanceOperationResult = Types.ApplyInstanceOperationResult
+type ApplyInstanceOperationsResponse = Types.ApplyInstanceOperationsResponse
 
 local CREATE_CLASS_ALLOWLIST = {
         Folder = true,
@@ -21,6 +23,11 @@ local CREATE_CLASS_ALLOWLIST = {
         BillboardGui = true,
         ScreenGui = true,
         Attachment = true,
+}
+
+local ROOT_DELETE_ALLOWLIST = {
+        Folder = true,
+        Model = true,
 }
 
 local PROPERTY_ALLOWLIST: { [string]: { [string]: true } } = {
@@ -77,10 +84,19 @@ local PROPERTY_ALLOWLIST: { [string]: { [string]: true } } = {
 }
 
 local function clonePath(path: Types.InstancePath): { string }
-        local result = table.create(#path)
-        for _, segment in path do
-                table.insert(result, segment)
+        local result = {}
+        if type(path) ~= "table" then
+                return result
         end
+
+        local count = #path
+        if count > 0 then
+                result = table.create(count)
+                for _, segment in path do
+                        table.insert(result, segment)
+                end
+        end
+
         return result
 end
 
@@ -302,6 +318,20 @@ local function applyDelete(operation: ApplyInstanceOperation): (boolean, string?
                 return false, errorMessage
         end
 
+        if target == game then
+                return false, "Destroying the DataModel root is not permitted"
+        end
+
+        if target.Parent == game then
+                local className = target.ClassName
+                if className:sub(-7) == "Service" then
+                        return false, string.format("Destroying %s services is not permitted", className)
+                end
+                if not ROOT_DELETE_ALLOWLIST[className] then
+                        return false, string.format("Destroying top-level %s instances is not permitted", className)
+                end
+        end
+
         local ok, err = pcall(function()
                 target:Destroy()
         end)
@@ -319,7 +349,7 @@ local ACTION_HANDLERS: { [Types.InstanceOperationAction]: (ApplyInstanceOperatio
         delete = applyDelete,
 }
 
-local function applyOperations(params: ApplyInstanceOperationsArgs): { [string]: any }
+local function applyOperations(params: ApplyInstanceOperationsArgs): ApplyInstanceOperationsResponse
         local operations = params.operations
         if type(operations) ~= "table" or #operations == 0 then
                 error("apply_instance_operations requires at least one operation")
@@ -330,7 +360,7 @@ local function applyOperations(params: ApplyInstanceOperationsArgs): { [string]:
                 ChangeHistoryService:SetWaypoint("Before ApplyInstanceOperations")
         end
 
-        local results = table.create(#operations)
+        local results: { ApplyInstanceOperationResult } = table.create(#operations)
         local successes = 0
 
         for index, operation in operations do
@@ -339,7 +369,7 @@ local function applyOperations(params: ApplyInstanceOperationsArgs): { [string]:
                         results[index] = {
                                 index = index,
                                 action = operation.action,
-                                path = operation.path,
+                                path = clonePath(operation.path),
                                 success = false,
                                 message = string.format("Unsupported action '%s'", tostring(operation.action)),
                         }
@@ -351,7 +381,7 @@ local function applyOperations(params: ApplyInstanceOperationsArgs): { [string]:
                         results[index] = {
                                 index = index,
                                 action = operation.action,
-                                path = operation.path,
+                                path = clonePath(operation.path),
                                 success = success,
                                 message = message,
                         }
@@ -367,11 +397,17 @@ local function applyOperations(params: ApplyInstanceOperationsArgs): { [string]:
                         end
         end
 
-        local summary = string.format("Applied %d/%d operations", successes, #operations)
+        local total = #operations
+        local failures = total - successes
+        local summary = string.format("Applied %d of %d operations", successes, total)
+        if failures > 0 then
+                summary ..= string.format(" (%d failed)", failures)
+        end
+
         return {
                 results = results,
                 summary = summary,
-                success = successes == #operations,
+                writeOccurred = successes > 0,
         }
 end
 

--- a/plugin/src/Types.luau
+++ b/plugin/src/Types.luau
@@ -257,6 +257,20 @@ export type ApplyInstanceOperationsArgs = {
         operations: { ApplyInstanceOperation },
 }
 
+export type ApplyInstanceOperationResult = {
+        index: number,
+        action: InstanceOperationAction,
+        path: InstancePath,
+        success: boolean,
+        message: string?,
+}
+
+export type ApplyInstanceOperationsResponse = {
+        results: { ApplyInstanceOperationResult },
+        summary: string?,
+        writeOccurred: boolean,
+}
+
 export type ScriptPath = { string }
 
 export type ScriptMetadataRequest = {

--- a/src/rbx_studio_server.rs
+++ b/src/rbx_studio_server.rs
@@ -204,6 +204,9 @@ struct ApplyInstanceOperationsResponse {
     #[serde(default)]
     #[schemars(description = "High level summary of the batch execution")]
     summary: Option<String>,
+    #[serde(default)]
+    #[schemars(description = "True when at least one operation mutated the DataModel")]
+    write_occurred: bool,
 }
 
 fn default_true() -> bool {


### PR DESCRIPTION
## Summary
- extend the ApplyInstanceOperations response schema with a writeOccurred flag and queue handler wiring
- harden the Studio plugin tool with path cloning, service delete guards, ChangeHistory checkpoints, and structured results
- document bulk instance editing prompts and safety checks for property allowlists and undo support

## Testing
- cargo fmt

------
https://chatgpt.com/codex/tasks/task_b_68e5f5186f0c832fa769e0571fd2a910