### PR TITLE
Filter asset marketplace searches by creator

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,7 +446,8 @@ containing a `results` array with per-step status, messages, and structured `det
 ### Supported operations
 
 - `search_marketplace` – Query the Roblox marketplace and return asset metadata (name, creator,
-  asset and version IDs). Use `limit` to cap the number of results (default `10`, max `50`).
+  asset and version IDs). Use `limit` to cap the number of results (default `10`, max `50`) and
+  `creatorName` to filter matches to a specific creator.
 - `insert_asset_version` – Load a specific asset version via `InsertService:LoadAssetVersion`, handle
   naming collisions (`rename`, `overwrite`, or `skip`), place the instance in a target parent, pivot
   it (`camera`, `origin`, `preserve`, or `custom_cframe`), and optionally publish the inserted

--- a/plugin/src/Tools/AssetPipeline.luau
+++ b/plugin/src/Tools/AssetPipeline.luau
@@ -374,6 +374,7 @@ local function processSearchMarketplace(operation: Types.AssetPipelineSearchMark
         end
 
         local limit = clamp(math.floor(operation.limit or 10), 1, 50)
+        local creatorFilter = if type(operation.creatorName) == "string" and operation.creatorName ~= "" then string.lower(operation.creatorName) else nil
         local success, response = pcall(function()
                 return InsertService:GetFreeModels(operation.query, 0)
         end)
@@ -392,19 +393,25 @@ local function processSearchMarketplace(operation: Types.AssetPipelineSearchMark
                 results = {},
         }
 
+        if creatorFilter then
+                details.creatorFilter = operation.creatorName
+        end
+
         local count = 0
         if type(response) == "table" and response[1] and type(response[1]) == "table" and response[1].Results then
                 for _, entry in response[1].Results do
                         if type(entry) == "table" then
-                                table.insert(details.results, {
-                                        name = entry.Name,
-                                        assetId = entry.AssetId,
-                                        assetVersionId = entry.AssetVersionId,
-                                        creatorName = entry.CreatorName,
-                                })
-                                count += 1
-                                if count >= limit then
-                                        break
+                                if not creatorFilter or (type(entry.CreatorName) == "string" and string.lower(entry.CreatorName) == creatorFilter) then
+                                        table.insert(details.results, {
+                                                name = entry.Name,
+                                                assetId = entry.AssetId,
+                                                assetVersionId = entry.AssetVersionId,
+                                                creatorName = entry.CreatorName,
+                                        })
+                                        count += 1
+                                        if count >= limit then
+                                                break
+                                        end
                                 end
                         end
                 end


### PR DESCRIPTION
## Summary
- allow asset pipeline marketplace searches to filter by creator name when provided
- document the new optional creatorName filter in the asset pipeline section of the README

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e6129cff9c832f8e310db4373b5076