### PR TITLE
Add EnvironmentControl tool for ambience tuning

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,12 @@ Claude Desktop and Cursor expose the following Roblox Studio tooling through thi
     `services = { "Workspace", "Players", ... }` to customize the list and set `includeCounts`
     (default `true`) to gather descendant totals. The plugin serializes the results with
     `HttpService:JSONEncode`, so responses are safe to parse directly in Claude/Cursor prompts.
+- **`environment_control`** – Shape ambience and audio in one request. You can tune lighting colors,
+  `ClockTime`, `FogEnd`, and rendering technology, automatically create/update `Atmosphere`, `Sky`,
+  and post-processing effects, retint `Workspace.Terrain` water, and set `SoundService` properties or
+  trigger specific `Sound` instances (swap `SoundId`, adjust `Volume`, and optionally `Play`/`Stop`).
+  The plugin validates every value and wraps the batch in a single change-history recording so failed
+  edits roll back cleanly.
 - **`apply_instance_operations`** – Perform bulk instance edits (create/update/delete/reparent/clone/
   bulk_set_properties) in a single checkpointed ChangeHistory batch. Operations accept structured
   payloads so you can rename or move instances, spawn new assets, or fan out property edits across
@@ -219,6 +225,19 @@ Claude Desktop and Cursor expose the following Roblox Studio tooling through thi
       }
     }
     ```
+
+### Environment control prompt ideas
+
+You can pair the new ambience controls with natural-language requests. Try prompts such as:
+
+- “Set the place to a warm sunset: clock time 18.5, ambient/outdoor ambient to a soft orange, fog
+  rolling in at 80 studs, and enable sun rays for the sunrise vibe.”
+- “Make the campsite feel misty at night. Add a thicker atmosphere haze, lower the fog end to 120,
+  and switch the lighting technology to Future.”
+- “Spin up an underwater soundscape by setting SoundService ambient reverb to UnderWater, boosting
+  terrain water transparency to 0.7, and playing `rbxassetid://184352123` on the `Workspace.Audio.
+  OceanLoop` sound at half volume.”
+
 - **`physics_and_navigation`** – Coordinate collision group authoring with navigation queries in a
   single request. The tool understands four operation types that can be mixed in one batch:
   - `create_collision_group` creates or replaces a group and can immediately toggle its active state.

--- a/plugin/src/Tools/EnvironmentControl.luau
+++ b/plugin/src/Tools/EnvironmentControl.luau
@@ -1,0 +1,1146 @@
+local Main = script:FindFirstAncestor("MCPStudioPlugin")
+local Types = require(Main.Types)
+
+local ChangeHistoryService = game:GetService("ChangeHistoryService")
+local HttpService = game:GetService("HttpService")
+local Lighting = game:GetService("Lighting")
+local SoundService = game:GetService("SoundService")
+local Workspace = game:GetService("Workspace")
+
+local Terrain = Workspace.Terrain
+
+local SECTION_SUMMARY_LABELS = {
+        lighting = "lighting",
+        atmosphere = "atmosphere",
+        sky = "sky",
+        post_processing = "post-processing",
+        terrain = "terrain water",
+        sound_service = "SoundService",
+        sounds = "sound instances",
+}
+
+type EnvironmentControlRequest = Types.EnvironmentControlRequest
+type EnvironmentControlResponse = Types.EnvironmentControlResponse
+type LightingSettings = Types.LightingSettings
+type AtmosphereSettings = Types.AtmosphereSettings
+type SkySettings = Types.SkySettings
+type TerrainWaterSettings = Types.TerrainWaterSettings
+type SoundServiceSettings = Types.SoundServiceSettings
+type SoundInstanceControl = Types.SoundInstanceControl
+type PostProcessingEffectEdit = Types.PostProcessingEffectEdit
+type Color3Components = Types.Color3Components
+
+type ToolArgs = Types.ToolArgs
+
+type SectionSet = { [string]: boolean }
+
+local function jsonEncode(payload: EnvironmentControlResponse): string
+        return HttpService:JSONEncode(payload)
+end
+
+local function isFiniteNumber(value: any): boolean
+        return typeof(value) == "number" and value == value and value ~= math.huge and value ~= -math.huge
+end
+
+local function parseNumber(value: any, name: string, minValue: number?, maxValue: number?): (number?, string?)
+        if not isFiniteNumber(value) then
+                return nil, string.format("%s must be a finite number", name)
+        end
+        local numeric = value :: number
+        if minValue and numeric < minValue then
+                return nil, string.format("%s must be >= %s", name, tostring(minValue))
+        end
+        if maxValue and numeric > maxValue then
+                return nil, string.format("%s must be <= %s", name, tostring(maxValue))
+        end
+        return numeric, nil
+end
+
+local function parseColor(components: Color3Components?, context: string): (Color3?, string?)
+        if type(components) ~= "table" then
+                return nil, string.format("%s must be an object with r, g, b fields", context)
+        end
+
+        local r = components.r
+        local g = components.g
+        local b = components.b
+
+        if not isFiniteNumber(r) then
+                return nil, string.format("%s.r must be a finite number", context)
+        end
+        if not isFiniteNumber(g) then
+                return nil, string.format("%s.g must be a finite number", context)
+        end
+        if not isFiniteNumber(b) then
+                return nil, string.format("%s.b must be a finite number", context)
+        end
+
+        local function normaliseChannel(value: number): number
+                if value > 1 then
+                        return math.clamp(value / 255, 0, 1)
+                end
+                if value < 0 then
+                        return 0
+                end
+                if value > 1 then
+                        return 1
+                end
+                return value
+        end
+
+        return Color3.new(normaliseChannel(r), normaliseChannel(g), normaliseChannel(b)), nil
+end
+
+local function formatColor(color: Color3): string
+        return string.format("(%.3f, %.3f, %.3f)", color.R, color.G, color.B)
+end
+
+local function recordChange(changes: { string }, sections: SectionSet, section: string, message: string)
+        table.insert(changes, message)
+        sections[section] = true
+end
+
+local function normalisePath(path: Types.InstancePath?): { string }
+        local normalised = {}
+        if type(path) ~= "table" then
+                return normalised
+        end
+
+        for _, segment in path do
+                if type(segment) == "string" and segment ~= "" and segment ~= "game" and segment ~= "DataModel" then
+                        table.insert(normalised, segment)
+                end
+        end
+
+        return normalised
+end
+
+local function resolveInstance(path: Types.InstancePath?): (Instance?, string?)
+        local normalised = normalisePath(path)
+        if #normalised == 0 then
+                return nil, "A non-empty instance path is required"
+        end
+
+        local current: Instance = game
+        for index, segment in normalised do
+                local nextInstance = current:FindFirstChild(segment)
+                if not nextInstance then
+                        local parentName = if index == 1 then "game" else current:GetFullName()
+                        return nil, string.format("Unable to find '%s' under %s", segment, parentName)
+                end
+                current = nextInstance
+        end
+
+        return current, nil
+end
+
+local function matchEnumItem(enum: Enum, name: string?, context: string): (EnumItem?, string?)
+        if type(name) ~= "string" or name == "" then
+                return nil, string.format("%s must be a non-empty string", context)
+        end
+
+        local candidate = enum[name]
+        if candidate then
+                return candidate, nil
+        end
+
+        local lower = string.lower(name)
+        for _, item in enum:GetEnumItems() do
+                if string.lower(item.Name) == lower then
+                        return item, nil
+                end
+        end
+
+        return nil, string.format("Unknown %s '%s'", context, name)
+end
+
+local function applyLighting(settings: LightingSettings?, changes: { string }, sections: SectionSet): (boolean, string?)
+        if settings == nil then
+                return true, nil
+        end
+        if type(settings) ~= "table" then
+                return false, "lighting settings must be an object"
+        end
+
+        local applied = false
+
+        if settings.ambient ~= nil then
+                local color, err = parseColor(settings.ambient, "lighting.ambient")
+                if not color then
+                        return false, err
+                end
+                Lighting.Ambient = color
+                recordChange(changes, sections, "lighting", "Lighting.Ambient -> " .. formatColor(color))
+                applied = true
+        end
+
+        if settings.outdoorAmbient ~= nil then
+                local color, err = parseColor(settings.outdoorAmbient, "lighting.outdoorAmbient")
+                if not color then
+                        return false, err
+                end
+                Lighting.OutdoorAmbient = color
+                recordChange(changes, sections, "lighting", "Lighting.OutdoorAmbient -> " .. formatColor(color))
+                applied = true
+        end
+
+        if settings.brightness ~= nil then
+                local value, err = parseNumber(settings.brightness, "lighting.brightness", 0, nil)
+                if not value then
+                        return false, err
+                end
+                Lighting.Brightness = value
+                recordChange(changes, sections, "lighting", string.format("Lighting.Brightness -> %.3f", value))
+                applied = true
+        end
+
+        if settings.clockTime ~= nil then
+                local value, err = parseNumber(settings.clockTime, "lighting.clockTime", 0, 24)
+                if not value then
+                        return false, err
+                end
+                Lighting.ClockTime = value
+                recordChange(changes, sections, "lighting", string.format("Lighting.ClockTime -> %.3f", value))
+                applied = true
+        end
+
+        if settings.fogColor ~= nil then
+                local color, err = parseColor(settings.fogColor, "lighting.fogColor")
+                if not color then
+                        return false, err
+                end
+                Lighting.FogColor = color
+                recordChange(changes, sections, "lighting", "Lighting.FogColor -> " .. formatColor(color))
+                applied = true
+        end
+
+        if settings.fogStart ~= nil then
+                local value, err = parseNumber(settings.fogStart, "lighting.fogStart", 0, nil)
+                if not value then
+                        return false, err
+                end
+                Lighting.FogStart = value
+                recordChange(changes, sections, "lighting", string.format("Lighting.FogStart -> %.3f", value))
+                applied = true
+        end
+
+        if settings.fogEnd ~= nil then
+                local value, err = parseNumber(settings.fogEnd, "lighting.fogEnd", 0, nil)
+                if not value then
+                        return false, err
+                end
+                Lighting.FogEnd = value
+                recordChange(changes, sections, "lighting", string.format("Lighting.FogEnd -> %.3f", value))
+                applied = true
+        end
+
+        if settings.technology ~= nil then
+                local technology, err = matchEnumItem(Enum.Technology, settings.technology, "lighting.technology")
+                if not technology then
+                        return false, err
+                end
+                Lighting.Technology = technology
+                recordChange(changes, sections, "lighting", "Lighting.Technology -> " .. technology.Name)
+                applied = true
+        end
+
+        if applied then
+                sections.lighting = true
+        end
+
+        return true, nil
+end
+
+local function ensureChildOfClass(parent: Instance, className: string, desiredName: string?): Instance
+        if desiredName and desiredName ~= "" then
+                local existing = parent:FindFirstChild(desiredName)
+                if existing and existing:IsA(className) then
+                        return existing
+                end
+        end
+
+        local found = parent:FindFirstChildOfClass(className)
+        if found then
+                        if desiredName and desiredName ~= "" then
+                                found.Name = desiredName
+                        end
+                        return found
+        end
+
+        local instance = Instance.new(className)
+        instance.Name = desiredName or className
+        instance.Parent = parent
+        return instance
+end
+
+local function applyAtmosphere(settings: AtmosphereSettings?, changes: { string }, sections: SectionSet): (boolean, string?)
+        if settings == nil then
+                return true, nil
+        end
+        if type(settings) ~= "table" then
+                return false, "atmosphere settings must be an object"
+        end
+
+        local atmosphere = ensureChildOfClass(Lighting, "Atmosphere", "MCPAtmosphere")
+        local applied = false
+
+        if settings.density ~= nil then
+                local value, err = parseNumber(settings.density, "atmosphere.density", 0, 1)
+                if not value then
+                        return false, err
+                end
+                atmosphere.Density = value
+                recordChange(changes, sections, "atmosphere", string.format("Atmosphere.Density -> %.3f", value))
+                applied = true
+        end
+
+        if settings.offset ~= nil then
+                local value, err = parseNumber(settings.offset, "atmosphere.offset", -1, 1)
+                if not value then
+                        return false, err
+                end
+                atmosphere.Offset = value
+                recordChange(changes, sections, "atmosphere", string.format("Atmosphere.Offset -> %.3f", value))
+                applied = true
+        end
+
+        if settings.glare ~= nil then
+                local value, err = parseNumber(settings.glare, "atmosphere.glare", 0, 1)
+                if not value then
+                        return false, err
+                end
+                atmosphere.Glare = value
+                recordChange(changes, sections, "atmosphere", string.format("Atmosphere.Glare -> %.3f", value))
+                applied = true
+        end
+
+        if settings.haze ~= nil then
+                local value, err = parseNumber(settings.haze, "atmosphere.haze", 0, 1)
+                if not value then
+                        return false, err
+                end
+                atmosphere.Haze = value
+                recordChange(changes, sections, "atmosphere", string.format("Atmosphere.Haze -> %.3f", value))
+                applied = true
+        end
+
+        if settings.color ~= nil then
+                local color, err = parseColor(settings.color, "atmosphere.color")
+                if not color then
+                        return false, err
+                end
+                atmosphere.Color = color
+                recordChange(changes, sections, "atmosphere", "Atmosphere.Color -> " .. formatColor(color))
+                applied = true
+        end
+
+        if settings.decay ~= nil then
+                local color, err = parseColor(settings.decay, "atmosphere.decay")
+                if not color then
+                        return false, err
+                end
+                atmosphere.Decay = color
+                recordChange(changes, sections, "atmosphere", "Atmosphere.Decay -> " .. formatColor(color))
+                applied = true
+        end
+
+        if applied then
+                sections.atmosphere = true
+        end
+
+        return true, nil
+end
+
+local function applySky(settings: SkySettings?, changes: { string }, sections: SectionSet): (boolean, string?)
+        if settings == nil then
+                return true, nil
+        end
+        if type(settings) ~= "table" then
+                return false, "sky settings must be an object"
+        end
+
+        local sky = ensureChildOfClass(Lighting, "Sky", "MCPSky")
+        local applied = false
+
+        local function assignStringProperty(propertyName: string, value: any, context: string)
+                if type(value) ~= "string" then
+                        return false, string.format("%s must be a string", context)
+                end
+                sky[propertyName] = value
+                recordChange(changes, sections, "sky", string.format("Sky.%s -> %s", propertyName, value))
+                return true, nil
+        end
+
+        if settings.skyboxBk ~= nil then
+                local ok, err = assignStringProperty("SkyboxBk", settings.skyboxBk, "sky.skyboxBk")
+                if not ok then
+                        return false, err
+                end
+                applied = true
+        end
+        if settings.skyboxDn ~= nil then
+                local ok, err = assignStringProperty("SkyboxDn", settings.skyboxDn, "sky.skyboxDn")
+                if not ok then
+                        return false, err
+                end
+                applied = true
+        end
+        if settings.skyboxFt ~= nil then
+                local ok, err = assignStringProperty("SkyboxFt", settings.skyboxFt, "sky.skyboxFt")
+                if not ok then
+                        return false, err
+                end
+                applied = true
+        end
+        if settings.skyboxLf ~= nil then
+                local ok, err = assignStringProperty("SkyboxLf", settings.skyboxLf, "sky.skyboxLf")
+                if not ok then
+                        return false, err
+                end
+                applied = true
+        end
+        if settings.skyboxRt ~= nil then
+                local ok, err = assignStringProperty("SkyboxRt", settings.skyboxRt, "sky.skyboxRt")
+                if not ok then
+                        return false, err
+                end
+                applied = true
+        end
+        if settings.skyboxUp ~= nil then
+                local ok, err = assignStringProperty("SkyboxUp", settings.skyboxUp, "sky.skyboxUp")
+                if not ok then
+                        return false, err
+                end
+                applied = true
+        end
+        if settings.sunTextureId ~= nil then
+                local ok, err = assignStringProperty("SunTextureId", settings.sunTextureId, "sky.sunTextureId")
+                if not ok then
+                        return false, err
+                end
+                applied = true
+        end
+        if settings.moonTextureId ~= nil then
+                local ok, err = assignStringProperty("MoonTextureId", settings.moonTextureId, "sky.moonTextureId")
+                if not ok then
+                        return false, err
+                end
+                applied = true
+        end
+        if settings.starCount ~= nil then
+                local value, err = parseNumber(settings.starCount, "sky.starCount", 0, 6000)
+                if not value then
+                        return false, err
+                end
+                sky.StarCount = value
+                recordChange(changes, sections, "sky", string.format("Sky.StarCount -> %.0f", value))
+                applied = true
+        end
+        if settings.celestialBodiesShown ~= nil then
+                if typeof(settings.celestialBodiesShown) ~= "boolean" then
+                        return false, "sky.celestialBodiesShown must be a boolean"
+                end
+                sky.CelestialBodiesShown = settings.celestialBodiesShown
+                recordChange(
+                        changes,
+                        sections,
+                        "sky",
+                        string.format("Sky.CelestialBodiesShown -> %s", tostring(settings.celestialBodiesShown))
+                )
+                applied = true
+        end
+
+        if applied then
+                sections.sky = true
+        end
+
+        return true, nil
+end
+
+local function applyTerrainWater(settings: TerrainWaterSettings?, changes: { string }, sections: SectionSet): (boolean, string?)
+        if settings == nil then
+                return true, nil
+        end
+        if type(settings) ~= "table" then
+                return false, "terrainWater settings must be an object"
+        end
+
+        local applied = false
+
+        if settings.waterColor ~= nil then
+                local color, err = parseColor(settings.waterColor, "terrainWater.waterColor")
+                if not color then
+                        return false, err
+                end
+                Terrain.WaterColor = color
+                recordChange(changes, sections, "terrain", "Terrain.WaterColor -> " .. formatColor(color))
+                applied = true
+        end
+        if settings.waterTransparency ~= nil then
+                local value, err = parseNumber(settings.waterTransparency, "terrainWater.waterTransparency", 0, 1)
+                if not value then
+                        return false, err
+                end
+                Terrain.WaterTransparency = value
+                recordChange(
+                        changes,
+                        sections,
+                        "terrain",
+                        string.format("Terrain.WaterTransparency -> %.3f", value)
+                )
+                applied = true
+        end
+        if settings.waterWaveSize ~= nil then
+                local value, err = parseNumber(settings.waterWaveSize, "terrainWater.waterWaveSize", 0, nil)
+                if not value then
+                        return false, err
+                end
+                Terrain.WaterWaveSize = value
+                recordChange(
+                        changes,
+                        sections,
+                        "terrain",
+                        string.format("Terrain.WaterWaveSize -> %.3f", value)
+                )
+                applied = true
+        end
+        if settings.waterWaveSpeed ~= nil then
+                local value, err = parseNumber(settings.waterWaveSpeed, "terrainWater.waterWaveSpeed", 0, nil)
+                if not value then
+                        return false, err
+                end
+                Terrain.WaterWaveSpeed = value
+                recordChange(
+                        changes,
+                        sections,
+                        "terrain",
+                        string.format("Terrain.WaterWaveSpeed -> %.3f", value)
+                )
+                applied = true
+        end
+
+        if applied then
+                sections.terrain = true
+        end
+
+        return true, nil
+end
+
+local function applySoundService(settings: SoundServiceSettings?, changes: { string }, sections: SectionSet): (boolean, string?)
+        if settings == nil then
+                return true, nil
+        end
+        if type(settings) ~= "table" then
+                return false, "soundService settings must be an object"
+        end
+
+        local applied = false
+
+        if settings.ambientReverb ~= nil then
+                local reverb, err = matchEnumItem(Enum.AmbientReverb, settings.ambientReverb, "soundService.ambientReverb")
+                if not reverb then
+                        return false, err
+                end
+                SoundService.AmbientReverb = reverb
+                recordChange(changes, sections, "sound_service", "SoundService.AmbientReverb -> " .. reverb.Name)
+                applied = true
+        end
+
+        if settings.respectFilteringEnabled ~= nil then
+                if typeof(settings.respectFilteringEnabled) ~= "boolean" then
+                        return false, "soundService.respectFilteringEnabled must be a boolean"
+                end
+                SoundService.RespectFilteringEnabled = settings.respectFilteringEnabled
+                recordChange(
+                        changes,
+                        sections,
+                        "sound_service",
+                        string.format(
+                                "SoundService.RespectFilteringEnabled -> %s",
+                                tostring(settings.respectFilteringEnabled)
+                        )
+                )
+                applied = true
+        end
+
+        if settings.dopplerScale ~= nil then
+                local value, err = parseNumber(settings.dopplerScale, "soundService.dopplerScale", 0, nil)
+                if not value then
+                        return false, err
+                end
+                SoundService.DopplerScale = value
+                recordChange(
+                        changes,
+                        sections,
+                        "sound_service",
+                        string.format("SoundService.DopplerScale -> %.3f", value)
+                )
+                applied = true
+        end
+
+        if settings.rolloffScale ~= nil then
+                local value, err = parseNumber(settings.rolloffScale, "soundService.rolloffScale", 0, nil)
+                if not value then
+                        return false, err
+                end
+                SoundService.RolloffScale = value
+                recordChange(
+                        changes,
+                        sections,
+                        "sound_service",
+                        string.format("SoundService.RolloffScale -> %.3f", value)
+                )
+                applied = true
+        end
+
+        if applied then
+                sections.sound_service = true
+        end
+
+        return true, nil
+end
+
+local function applyPostProcessing(edit: PostProcessingEffectEdit, changes: { string }, sections: SectionSet): (boolean, string?)
+        local effectType = (edit :: any).effect
+        if type(effectType) ~= "string" then
+                return false, "postProcessing entry missing effect discriminator"
+        end
+
+        local name = (edit :: any).name
+        if name ~= nil and typeof(name) ~= "string" then
+                return false, "postProcessing.name must be a string when provided"
+        end
+
+        local className
+        if effectType == "bloom" then
+                className = "BloomEffect"
+        elseif effectType == "color_correction" then
+                className = "ColorCorrectionEffect"
+        elseif effectType == "depth_of_field" then
+                className = "DepthOfFieldEffect"
+        elseif effectType == "sun_rays" then
+                className = "SunRaysEffect"
+        elseif effectType == "blur" then
+                className = "BlurEffect"
+        else
+                return false, string.format("Unsupported postProcessing effect '%s'", effectType)
+        end
+
+        local instance = ensureChildOfClass(Lighting, className, name)
+
+        local applied = false
+        local payload = edit :: any
+
+        if payload.enabled ~= nil then
+                if typeof(payload.enabled) ~= "boolean" then
+                        return false, string.format("postProcessing.%s.enabled must be a boolean", effectType)
+                end
+                instance.Enabled = payload.enabled
+                recordChange(
+                        changes,
+                        sections,
+                        "post_processing",
+                        string.format("%s.Enabled -> %s", instance.Name, tostring(payload.enabled))
+                )
+                applied = true
+        end
+
+        if effectType == "bloom" then
+                if payload.intensity ~= nil then
+                        local value, err = parseNumber(payload.intensity, "postProcessing.bloom.intensity", 0, nil)
+                        if not value then
+                                return false, err
+                        end
+                        instance.Intensity = value
+                        recordChange(
+                                changes,
+                                sections,
+                                "post_processing",
+                                string.format("%s.Intensity -> %.3f", instance.Name, value)
+                        )
+                        applied = true
+                end
+                if payload.size ~= nil then
+                        local value, err = parseNumber(payload.size, "postProcessing.bloom.size", 0, nil)
+                        if not value then
+                                return false, err
+                        end
+                        instance.Size = value
+                        recordChange(
+                                changes,
+                                sections,
+                                "post_processing",
+                                string.format("%s.Size -> %.3f", instance.Name, value)
+                        )
+                        applied = true
+                end
+                if payload.threshold ~= nil then
+                        local value, err = parseNumber(payload.threshold, "postProcessing.bloom.threshold", 0, 1)
+                        if not value then
+                                return false, err
+                        end
+                        instance.Threshold = value
+                        recordChange(
+                                changes,
+                                sections,
+                                "post_processing",
+                                string.format("%s.Threshold -> %.3f", instance.Name, value)
+                        )
+                        applied = true
+                end
+        elseif effectType == "color_correction" then
+                if payload.brightness ~= nil then
+                        local value, err = parseNumber(payload.brightness, "postProcessing.color_correction.brightness", -1, 1)
+                        if not value then
+                                return false, err
+                        end
+                        instance.Brightness = value
+                        recordChange(
+                                changes,
+                                sections,
+                                "post_processing",
+                                string.format("%s.Brightness -> %.3f", instance.Name, value)
+                        )
+                        applied = true
+                end
+                if payload.contrast ~= nil then
+                        local value, err = parseNumber(payload.contrast, "postProcessing.color_correction.contrast", -1, 1)
+                        if not value then
+                                return false, err
+                        end
+                        instance.Contrast = value
+                        recordChange(
+                                changes,
+                                sections,
+                                "post_processing",
+                                string.format("%s.Contrast -> %.3f", instance.Name, value)
+                        )
+                        applied = true
+                end
+                if payload.saturation ~= nil then
+                        local value, err = parseNumber(payload.saturation, "postProcessing.color_correction.saturation", -1, 1)
+                        if not value then
+                                return false, err
+                        end
+                        instance.Saturation = value
+                        recordChange(
+                                changes,
+                                sections,
+                                "post_processing",
+                                string.format("%s.Saturation -> %.3f", instance.Name, value)
+                        )
+                        applied = true
+                end
+                if payload.tintColor ~= nil then
+                        local color, err = parseColor(payload.tintColor, "postProcessing.color_correction.tintColor")
+                        if not color then
+                                return false, err
+                        end
+                        instance.TintColor = color
+                        recordChange(
+                                changes,
+                                sections,
+                                "post_processing",
+                                string.format("%s.TintColor -> %s", instance.Name, formatColor(color))
+                        )
+                        applied = true
+                end
+        elseif effectType == "depth_of_field" then
+                if payload.focusDistance ~= nil then
+                        local value, err = parseNumber(payload.focusDistance, "postProcessing.depth_of_field.focusDistance", 0, nil)
+                        if not value then
+                                return false, err
+                        end
+                        instance.FocusDistance = value
+                        recordChange(
+                                changes,
+                                sections,
+                                "post_processing",
+                                string.format("%s.FocusDistance -> %.3f", instance.Name, value)
+                        )
+                        applied = true
+                end
+                if payload.inFocusRadius ~= nil then
+                        local value, err = parseNumber(payload.inFocusRadius, "postProcessing.depth_of_field.inFocusRadius", 0, nil)
+                        if not value then
+                                return false, err
+                        end
+                        instance.InFocusRadius = value
+                        recordChange(
+                                changes,
+                                sections,
+                                "post_processing",
+                                string.format("%s.InFocusRadius -> %.3f", instance.Name, value)
+                        )
+                        applied = true
+                end
+                if payload.nearIntensity ~= nil then
+                        local value, err = parseNumber(payload.nearIntensity, "postProcessing.depth_of_field.nearIntensity", 0, 1)
+                        if not value then
+                                return false, err
+                        end
+                        instance.NearIntensity = value
+                        recordChange(
+                                changes,
+                                sections,
+                                "post_processing",
+                                string.format("%s.NearIntensity -> %.3f", instance.Name, value)
+                        )
+                        applied = true
+                end
+                if payload.farIntensity ~= nil then
+                        local value, err = parseNumber(payload.farIntensity, "postProcessing.depth_of_field.farIntensity", 0, 1)
+                        if not value then
+                                return false, err
+                        end
+                        instance.FarIntensity = value
+                        recordChange(
+                                changes,
+                                sections,
+                                "post_processing",
+                                string.format("%s.FarIntensity -> %.3f", instance.Name, value)
+                        )
+                        applied = true
+                end
+        elseif effectType == "sun_rays" then
+                if payload.intensity ~= nil then
+                        local value, err = parseNumber(payload.intensity, "postProcessing.sun_rays.intensity", 0, 1)
+                        if not value then
+                                return false, err
+                        end
+                        instance.Intensity = value
+                        recordChange(
+                                changes,
+                                sections,
+                                "post_processing",
+                                string.format("%s.Intensity -> %.3f", instance.Name, value)
+                        )
+                        applied = true
+                end
+                if payload.spread ~= nil then
+                        local value, err = parseNumber(payload.spread, "postProcessing.sun_rays.spread", 0, 1)
+                        if not value then
+                                return false, err
+                        end
+                        instance.Spread = value
+                        recordChange(
+                                changes,
+                                sections,
+                                "post_processing",
+                                string.format("%s.Spread -> %.3f", instance.Name, value)
+                        )
+                        applied = true
+                end
+        elseif effectType == "blur" then
+                if payload.size ~= nil then
+                        local value, err = parseNumber(payload.size, "postProcessing.blur.size", 0, 100)
+                        if not value then
+                                return false, err
+                        end
+                        instance.Size = value
+                        recordChange(
+                                changes,
+                                sections,
+                                "post_processing",
+                                string.format("%s.Size -> %.3f", instance.Name, value)
+                        )
+                        applied = true
+                end
+        end
+
+        if applied then
+                sections.post_processing = true
+        end
+
+        return true, nil
+end
+
+local function applyPostProcessingBatch(edits: { PostProcessingEffectEdit }?, changes: { string }, sections: SectionSet): (boolean, string?)
+        if edits == nil then
+                return true, nil
+        end
+        if type(edits) ~= "table" then
+                return false, "postProcessing must be an array"
+        end
+
+        for index, edit in edits do
+                local success, err = applyPostProcessing(edit, changes, sections)
+                if not success then
+                        return false, string.format("postProcessing[%d]: %s", index, err)
+                end
+        end
+
+        return true, nil
+end
+
+local function describeInstance(instance: Instance): string
+        return instance:GetFullName()
+end
+
+local function applySoundTargets(targets: { SoundInstanceControl }?, changes: { string }, sections: SectionSet): (boolean, string?)
+        if targets == nil then
+                return true, nil
+        end
+        if type(targets) ~= "table" then
+                return false, "sounds must be an array"
+        end
+
+        for index, control in targets do
+                if type(control) ~= "table" then
+                        return false, string.format("sounds[%d] must be an object", index)
+                end
+
+                local instance, resolveError = resolveInstance(control.path)
+                if not instance then
+                        return false, string.format("sounds[%d]: %s", index, resolveError or "unable to resolve path")
+                end
+
+                if not instance:IsA("Sound") then
+                        return false, string.format(
+                                "sounds[%d]: Resolved instance %s is not a Sound",
+                                index,
+                                describeInstance(instance)
+                        )
+                end
+
+                local applied = false
+
+                if control.soundId ~= nil then
+                        if type(control.soundId) ~= "string" then
+                                return false, string.format("sounds[%d].soundId must be a string", index)
+                        end
+                        instance.SoundId = control.soundId
+                        recordChange(
+                                changes,
+                                sections,
+                                "sounds",
+                                string.format("%s.SoundId -> %s", describeInstance(instance), control.soundId)
+                        )
+                        applied = true
+                end
+
+                if control.volume ~= nil then
+                        local value, err = parseNumber(control.volume, string.format("sounds[%d].volume", index), 0, nil)
+                        if not value then
+                                return false, err
+                        end
+                        instance.Volume = value
+                        recordChange(
+                                changes,
+                                sections,
+                                "sounds",
+                                string.format("%s.Volume -> %.3f", describeInstance(instance), value)
+                        )
+                        applied = true
+                end
+
+                if control.playbackSpeed ~= nil then
+                        local value, err = parseNumber(
+                                control.playbackSpeed,
+                                string.format("sounds[%d].playbackSpeed", index),
+                                0.01,
+                                nil
+                        )
+                        if not value then
+                                return false, err
+                        end
+                        instance.PlaybackSpeed = value
+                        recordChange(
+                                changes,
+                                sections,
+                                "sounds",
+                                string.format("%s.PlaybackSpeed -> %.3f", describeInstance(instance), value)
+                        )
+                        applied = true
+                end
+
+                if control.looped ~= nil then
+                        if typeof(control.looped) ~= "boolean" then
+                                return false, string.format("sounds[%d].looped must be a boolean", index)
+                        end
+                        instance.Looped = control.looped
+                        recordChange(
+                                changes,
+                                sections,
+                                "sounds",
+                                string.format("%s.Looped -> %s", describeInstance(instance), tostring(control.looped))
+                        )
+                        applied = true
+                end
+
+                if control.timePosition ~= nil then
+                        local value, err = parseNumber(
+                                control.timePosition,
+                                string.format("sounds[%d].timePosition", index),
+                                0,
+                                nil
+                        )
+                        if not value then
+                                return false, err
+                        end
+                        instance.TimePosition = value
+                        recordChange(
+                                changes,
+                                sections,
+                                "sounds",
+                                string.format("%s.TimePosition -> %.3f", describeInstance(instance), value)
+                        )
+                        applied = true
+                end
+
+                local playFlag = control.play
+                local stopFlag = control.stop
+                if playFlag and stopFlag then
+                        return false, string.format("sounds[%d] cannot request both play and stop", index)
+                end
+
+                if playFlag ~= nil and typeof(playFlag) ~= "boolean" then
+                        return false, string.format("sounds[%d].play must be a boolean", index)
+                end
+                if stopFlag ~= nil and typeof(stopFlag) ~= "boolean" then
+                        return false, string.format("sounds[%d].stop must be a boolean", index)
+                end
+
+                if playFlag then
+                        instance:Play()
+                        recordChange(
+                                changes,
+                                sections,
+                                "sounds",
+                                string.format("%s:Play()", describeInstance(instance))
+                        )
+                        applied = true
+                elseif stopFlag then
+                        instance:Stop()
+                        recordChange(
+                                changes,
+                                sections,
+                                "sounds",
+                                string.format("%s:Stop()", describeInstance(instance))
+                        )
+                        applied = true
+                end
+
+                if applied then
+                        sections.sounds = true
+                end
+        end
+
+        return true, nil
+end
+
+local function summariseSections(sections: SectionSet, hadChanges: boolean): string
+        if not hadChanges then
+                return "No environment changes were applied"
+        end
+
+        local labels = {}
+        for key in sections do
+                local label = SECTION_SUMMARY_LABELS[key] or key
+                table.insert(labels, label)
+        end
+
+        table.sort(labels)
+
+        if #labels == 0 then
+                return "No environment changes were applied"
+        end
+
+        if #labels == 1 then
+                return string.format("Updated %s settings", labels[1])
+        end
+
+        local last = labels[#labels]
+        table.remove(labels, #labels)
+
+        if #labels == 1 then
+                return string.format("Updated %s and %s settings", labels[1], last)
+        end
+
+        return string.format("Updated %s, and %s settings", table.concat(labels, ", "), last)
+end
+
+return function(args: ToolArgs): string?
+        if args.tool ~= "EnvironmentControl" then
+                return nil
+        end
+
+        local params = args.params :: EnvironmentControlRequest
+        if type(params) ~= "table" then
+                local response: EnvironmentControlResponse = {
+                        success = false,
+                        summary = nil,
+                        changes = nil,
+                        errors = { "EnvironmentControl requires an object payload" },
+                }
+                return jsonEncode(response)
+        end
+
+        local changes = {}
+        local sections: SectionSet = {}
+        local errors = {}
+
+        local recording = ChangeHistoryService:TryBeginRecording("EnvironmentControl")
+        if recording then
+                ChangeHistoryService:SetWaypoint("Before EnvironmentControl")
+        end
+
+        local success = true
+
+        local function guardApply(callback)
+                if not success then
+                        return
+                end
+                local ok, message = callback()
+                if not ok then
+                        success = false
+                        table.insert(errors, message or "Unknown EnvironmentControl error")
+                end
+        end
+
+        guardApply(function()
+                return applyLighting(params.lighting, changes, sections)
+        end)
+
+        guardApply(function()
+                return applyAtmosphere(params.atmosphere, changes, sections)
+        end)
+
+        guardApply(function()
+                return applySky(params.sky, changes, sections)
+        end)
+
+        guardApply(function()
+                return applyPostProcessingBatch(params.postProcessing, changes, sections)
+        end)
+
+        guardApply(function()
+                return applyTerrainWater(params.terrainWater, changes, sections)
+        end)
+
+        guardApply(function()
+                return applySoundService(params.soundService, changes, sections)
+        end)
+
+        guardApply(function()
+                return applySoundTargets(params.sounds, changes, sections)
+        end)
+
+        if recording then
+                if success and #changes > 0 then
+                        ChangeHistoryService:SetWaypoint("After EnvironmentControl")
+                        ChangeHistoryService:FinishRecording(recording, Enum.FinishRecordingOperation.Commit)
+                else
+                        ChangeHistoryService:FinishRecording(recording, Enum.FinishRecordingOperation.Cancel)
+                end
+        end
+
+        local response: EnvironmentControlResponse = {
+                success = success,
+                summary = if success then summariseSections(sections, #changes > 0) else nil,
+                changes = if #changes > 0 then changes else nil,
+                errors = if #errors > 0 then errors else nil,
+        }
+
+        return jsonEncode(response)
+end

--- a/plugin/src/Types.luau
+++ b/plugin/src/Types.luau
@@ -77,6 +77,130 @@ export type InspectEnvironmentResponse = {
         },
 }
 
+export type Color3Components = { r: number, g: number, b: number }
+
+export type LightingSettings = {
+        ambient: Color3Components?,
+        outdoorAmbient: Color3Components?,
+        brightness: number?,
+        clockTime: number?,
+        fogColor: Color3Components?,
+        fogStart: number?,
+        fogEnd: number?,
+        technology: string?,
+}
+
+export type AtmosphereSettings = {
+        density: number?,
+        offset: number?,
+        color: Color3Components?,
+        decay: Color3Components?,
+        glare: number?,
+        haze: number?,
+}
+
+export type SkySettings = {
+        skyboxBk: string?,
+        skyboxDn: string?,
+        skyboxFt: string?,
+        skyboxLf: string?,
+        skyboxRt: string?,
+        skyboxUp: string?,
+        sunTextureId: string?,
+        moonTextureId: string?,
+        starCount: number?,
+        celestialBodiesShown: boolean?,
+}
+
+export type TerrainWaterSettings = {
+        waterColor: Color3Components?,
+        waterTransparency: number?,
+        waterWaveSize: number?,
+        waterWaveSpeed: number?,
+}
+
+export type SoundServiceSettings = {
+        ambientReverb: string?,
+        respectFilteringEnabled: boolean?,
+        dopplerScale: number?,
+        rolloffScale: number?,
+}
+
+export type SoundInstanceControl = {
+        path: InstancePath,
+        soundId: string?,
+        volume: number?,
+        playbackSpeed: number?,
+        looped: boolean?,
+        play: boolean?,
+        stop: boolean?,
+        timePosition: number?,
+}
+
+export type PostProcessingBaseEdit = {
+        effect: string,
+        name: string?,
+        enabled: boolean?,
+}
+
+export type BloomEffectEdit = PostProcessingBaseEdit & {
+        effect: "bloom",
+        intensity: number?,
+        size: number?,
+        threshold: number?,
+}
+
+export type ColorCorrectionEffectEdit = PostProcessingBaseEdit & {
+        effect: "color_correction",
+        brightness: number?,
+        contrast: number?,
+        saturation: number?,
+        tintColor: Color3Components?,
+}
+
+export type DepthOfFieldEffectEdit = PostProcessingBaseEdit & {
+        effect: "depth_of_field",
+        focusDistance: number?,
+        inFocusRadius: number?,
+        nearIntensity: number?,
+        farIntensity: number?,
+}
+
+export type SunRaysEffectEdit = PostProcessingBaseEdit & {
+        effect: "sun_rays",
+        intensity: number?,
+        spread: number?,
+}
+
+export type BlurEffectEdit = PostProcessingBaseEdit & {
+        effect: "blur",
+        size: number?,
+}
+
+export type PostProcessingEffectEdit =
+        BloomEffectEdit
+        | ColorCorrectionEffectEdit
+        | DepthOfFieldEffectEdit
+        | SunRaysEffectEdit
+        | BlurEffectEdit
+
+export type EnvironmentControlRequest = {
+        lighting: LightingSettings?,
+        atmosphere: AtmosphereSettings?,
+        sky: SkySettings?,
+        postProcessing: { PostProcessingEffectEdit }?,
+        terrainWater: TerrainWaterSettings?,
+        soundService: SoundServiceSettings?,
+        sounds: { SoundInstanceControl }?,
+}
+
+export type EnvironmentControlResponse = {
+        success: boolean,
+        summary: string?,
+        changes: { string }?,
+        errors: { string }?,
+}
+
 export type EditorSessionSetSelectionAction = {
         action: "set_selection",
         paths: { InstancePath },
@@ -557,6 +681,11 @@ export type CollectionAndAttributesToolArgs = {
 export type PhysicsAndNavigationToolArgs = {
         tool: "PhysicsAndNavigation",
         params: PhysicsAndNavigationRequest,
+}
+
+export type EnvironmentControlToolArgs = {
+        tool: "EnvironmentControl",
+        params: EnvironmentControlRequest,
 }
 
 export type ApplyInstanceOperationsToolArgs = {

--- a/src/rbx_studio_server.rs
+++ b/src/rbx_studio_server.rs
@@ -1229,6 +1229,295 @@ struct PhysicsAndNavigationRequest {
 
 #[derive(Debug, Deserialize, Serialize, schemars::JsonSchema, Clone)]
 #[serde(rename_all = "camelCase")]
+struct Color3Components {
+    #[schemars(description = "Red channel intensity between 0 and 1")]
+    r: f64,
+    #[schemars(description = "Green channel intensity between 0 and 1")]
+    g: f64,
+    #[schemars(description = "Blue channel intensity between 0 and 1")]
+    b: f64,
+}
+
+#[derive(Debug, Deserialize, Serialize, schemars::JsonSchema, Clone, Default)]
+#[serde(default, rename_all = "camelCase")]
+struct LightingSettings {
+    #[serde(default)]
+    #[schemars(description = "Ambient light color applied to the scene")]
+    ambient: Option<Color3Components>,
+    #[serde(default)]
+    #[schemars(description = "Outdoor ambient light color")]
+    outdoor_ambient: Option<Color3Components>,
+    #[serde(default)]
+    #[schemars(description = "Brightness applied to all lighting")]
+    brightness: Option<f64>,
+    #[serde(default)]
+    #[schemars(description = "Time of day represented as hours (0-24)")]
+    clock_time: Option<f64>,
+    #[serde(default)]
+    #[schemars(description = "Fog color tint")]
+    fog_color: Option<Color3Components>,
+    #[serde(default)]
+    #[schemars(description = "Fog start distance")]
+    fog_start: Option<f64>,
+    #[serde(default)]
+    #[schemars(description = "Fog end distance")]
+    fog_end: Option<f64>,
+    #[serde(default)]
+    #[schemars(description = "Lighting technology override (e.g. Future, ShadowMap)")]
+    technology: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Serialize, schemars::JsonSchema, Clone, Default)]
+#[serde(default, rename_all = "camelCase")]
+struct AtmosphereSettings {
+    #[serde(default)]
+    #[schemars(description = "Atmospheric density value")]
+    density: Option<f64>,
+    #[serde(default)]
+    #[schemars(description = "Atmosphere height offset")]
+    offset: Option<f64>,
+    #[serde(default)]
+    #[schemars(description = "Atmosphere color tint")]
+    color: Option<Color3Components>,
+    #[serde(default)]
+    #[schemars(description = "Decay color controlling horizon falloff")]
+    decay: Option<Color3Components>,
+    #[serde(default)]
+    #[schemars(description = "Glare intensity")]
+    glare: Option<f64>,
+    #[serde(default)]
+    #[schemars(description = "Haze contribution")]
+    haze: Option<f64>,
+}
+
+#[derive(Debug, Deserialize, Serialize, schemars::JsonSchema, Clone, Default)]
+#[serde(default, rename_all = "camelCase")]
+struct SkySettings {
+    #[serde(default)]
+    #[schemars(description = "Skybox asset id for the back face")]
+    skybox_bk: Option<String>,
+    #[serde(default)]
+    #[schemars(description = "Skybox asset id for the bottom face")]
+    skybox_dn: Option<String>,
+    #[serde(default)]
+    #[schemars(description = "Skybox asset id for the front face")]
+    skybox_ft: Option<String>,
+    #[serde(default)]
+    #[schemars(description = "Skybox asset id for the left face")]
+    skybox_lf: Option<String>,
+    #[serde(default)]
+    #[schemars(description = "Skybox asset id for the right face")]
+    skybox_rt: Option<String>,
+    #[serde(default)]
+    #[schemars(description = "Skybox asset id for the top face")]
+    skybox_up: Option<String>,
+    #[serde(default)]
+    #[schemars(description = "Sun texture asset id")]
+    sun_texture_id: Option<String>,
+    #[serde(default)]
+    #[schemars(description = "Moon texture asset id")]
+    moon_texture_id: Option<String>,
+    #[serde(default)]
+    #[schemars(description = "Number of stars visible in the sky")]
+    star_count: Option<f64>,
+    #[serde(default)]
+    #[schemars(description = "Toggle celestial bodies visibility")]
+    celestial_bodies_shown: Option<bool>,
+}
+
+#[derive(Debug, Deserialize, Serialize, schemars::JsonSchema, Clone, Default)]
+#[serde(default, rename_all = "camelCase")]
+struct TerrainWaterSettings {
+    #[serde(default)]
+    #[schemars(description = "Water color override")]
+    water_color: Option<Color3Components>,
+    #[serde(default)]
+    #[schemars(description = "Water transparency value (0-1)")]
+    water_transparency: Option<f64>,
+    #[serde(default)]
+    #[schemars(description = "Water wave size")]
+    water_wave_size: Option<f64>,
+    #[serde(default)]
+    #[schemars(description = "Water wave speed")]
+    water_wave_speed: Option<f64>,
+}
+
+#[derive(Debug, Deserialize, Serialize, schemars::JsonSchema, Clone, Default)]
+#[serde(default, rename_all = "camelCase")]
+struct SoundServiceSettings {
+    #[serde(default)]
+    #[schemars(description = "Ambient reverb preset name")]
+    ambient_reverb: Option<String>,
+    #[serde(default)]
+    #[schemars(description = "Respect FilteringEnabled flag for descendant sounds")]
+    respect_filtering_enabled: Option<bool>,
+    #[serde(default)]
+    #[schemars(description = "Doppler scale factor applied to 3D sounds")]
+    doppler_scale: Option<f64>,
+    #[serde(default)]
+    #[schemars(description = "Roll-off scale for sound attenuation")]
+    rolloff_scale: Option<f64>,
+}
+
+#[derive(Debug, Deserialize, Serialize, schemars::JsonSchema, Clone)]
+#[serde(rename_all = "camelCase")]
+struct SoundInstanceControl {
+    #[schemars(description = "Path to the Sound instance that should be modified")]
+    path: Vec<String>,
+    #[serde(default)]
+    #[schemars(description = "Sound asset id to assign")]
+    sound_id: Option<String>,
+    #[serde(default)]
+    #[schemars(description = "Volume level for the sound")]
+    volume: Option<f64>,
+    #[serde(default)]
+    #[schemars(description = "Playback speed multiplier")]
+    playback_speed: Option<f64>,
+    #[serde(default)]
+    #[schemars(description = "Looped toggle")]
+    looped: Option<bool>,
+    #[serde(default)]
+    #[schemars(description = "If true, play() will be triggered after applying property changes")]
+    play: Option<bool>,
+    #[serde(default)]
+    #[schemars(description = "If true, stop() will be triggered after applying property changes")]
+    stop: Option<bool>,
+    #[serde(default)]
+    #[schemars(description = "Optional playback position to seek to before applying play/stop")]
+    time_position: Option<f64>,
+}
+
+#[derive(Debug, Deserialize, Serialize, schemars::JsonSchema, Clone)]
+#[serde(tag = "effect", rename_all = "snake_case")]
+enum PostProcessingEffectEdit {
+    Bloom {
+        #[serde(default)]
+        #[schemars(description = "Optional instance name override to match or assign")]
+        name: Option<String>,
+        #[serde(default)]
+        #[schemars(description = "Enable or disable the effect")]
+        enabled: Option<bool>,
+        #[serde(default)]
+        #[schemars(description = "Bloom intensity value")]
+        intensity: Option<f64>,
+        #[serde(default)]
+        #[schemars(description = "Bloom size value")]
+        size: Option<f64>,
+        #[serde(default)]
+        #[schemars(description = "Bloom threshold value")]
+        threshold: Option<f64>,
+    },
+    ColorCorrection {
+        #[serde(default)]
+        #[schemars(description = "Optional instance name override to match or assign")]
+        name: Option<String>,
+        #[serde(default)]
+        #[schemars(description = "Enable or disable the effect")]
+        enabled: Option<bool>,
+        #[serde(default)]
+        #[schemars(description = "Brightness offset (-1 to 1)")]
+        brightness: Option<f64>,
+        #[serde(default)]
+        #[schemars(description = "Contrast multiplier (-1 to 1)")]
+        contrast: Option<f64>,
+        #[serde(default)]
+        #[schemars(description = "Saturation offset (-1 to 1)")]
+        saturation: Option<f64>,
+        #[serde(default)]
+        #[schemars(description = "Tint color for the correction")]
+        tint_color: Option<Color3Components>,
+    },
+    DepthOfField {
+        #[serde(default)]
+        #[schemars(description = "Optional instance name override to match or assign")]
+        name: Option<String>,
+        #[serde(default)]
+        #[schemars(description = "Enable or disable the effect")]
+        enabled: Option<bool>,
+        #[serde(default)]
+        #[schemars(description = "Focus distance for the depth of field")]
+        focus_distance: Option<f64>,
+        #[serde(default)]
+        #[schemars(description = "Radius of the in focus region")]
+        in_focus_radius: Option<f64>,
+        #[serde(default)]
+        #[schemars(description = "Intensity applied to near blur")]
+        near_intensity: Option<f64>,
+        #[serde(default)]
+        #[schemars(description = "Intensity applied to far blur")]
+        far_intensity: Option<f64>,
+    },
+    SunRays {
+        #[serde(default)]
+        #[schemars(description = "Optional instance name override to match or assign")]
+        name: Option<String>,
+        #[serde(default)]
+        #[schemars(description = "Enable or disable the effect")]
+        enabled: Option<bool>,
+        #[serde(default)]
+        #[schemars(description = "Sun rays intensity")]
+        intensity: Option<f64>,
+        #[serde(default)]
+        #[schemars(description = "Sun rays spread")]
+        spread: Option<f64>,
+    },
+    Blur {
+        #[serde(default)]
+        #[schemars(description = "Optional instance name override to match or assign")]
+        name: Option<String>,
+        #[serde(default)]
+        #[schemars(description = "Enable or disable the effect")]
+        enabled: Option<bool>,
+        #[serde(default)]
+        #[schemars(description = "Blur size value")]
+        size: Option<f64>,
+    },
+}
+
+#[derive(Debug, Deserialize, Serialize, schemars::JsonSchema, Clone, Default)]
+#[serde(default, rename_all = "camelCase")]
+struct EnvironmentControlRequest {
+    #[serde(default)]
+    #[schemars(description = "Lighting property overrides applied to the current place")]
+    lighting: Option<LightingSettings>,
+    #[serde(default)]
+    #[schemars(description = "Atmosphere overrides created under Lighting if needed")]
+    atmosphere: Option<AtmosphereSettings>,
+    #[serde(default)]
+    #[schemars(description = "Skybox overrides created under Lighting if needed")]
+    sky: Option<SkySettings>,
+    #[serde(default)]
+    #[schemars(description = "Post processing edits applied under Lighting")]
+    post_processing: Vec<PostProcessingEffectEdit>,
+    #[serde(default)]
+    #[schemars(description = "Workspace terrain water configuration")]
+    terrain_water: Option<TerrainWaterSettings>,
+    #[serde(default)]
+    #[schemars(description = "SoundService level configuration")]
+    sound_service: Option<SoundServiceSettings>,
+    #[serde(default)]
+    #[schemars(description = "Targeted sound instance adjustments")]
+    sounds: Vec<SoundInstanceControl>,
+}
+
+#[derive(Debug, Deserialize, Serialize, schemars::JsonSchema, Clone, Default)]
+#[serde(default, rename_all = "camelCase")]
+struct EnvironmentControlResponse {
+    #[schemars(description = "True if all requested adjustments were applied successfully")]
+    success: bool,
+    #[serde(default)]
+    #[schemars(description = "Human readable summary of the applied environment edits")]
+    summary: Option<String>,
+    #[serde(default)]
+    #[schemars(description = "List of granular property changes that were applied")]
+    changes: Vec<String>,
+    #[serde(default)]
+    #[schemars(description = "Validation or runtime issues encountered while applying edits")]
+    errors: Vec<String>,
+}
+
+#[derive(Debug, Deserialize, Serialize, schemars::JsonSchema, Clone)]
+#[serde(rename_all = "camelCase")]
 struct PhysicsAndNavigationOperationResult {
     #[schemars(description = "Index of the processed operation within the batch")]
     index: usize,
@@ -1263,6 +1552,7 @@ enum ToolArgumentValues {
     RunCode(RunCode),
     InsertModel(InsertModel),
     InspectEnvironment(InspectEnvironment),
+    EnvironmentControl(EnvironmentControlRequest),
     ApplyInstanceOperations(ApplyInstanceOperationsRequest),
     ManageScripts(ManageScriptsRequest),
     TestAndPlayControl(TestAndPlayControl),
@@ -1312,6 +1602,17 @@ impl RBXStudioServer {
         Parameters(args): Parameters<InspectEnvironment>,
     ) -> Result<CallToolResult, ErrorData> {
         self.generic_tool_run(ToolArgumentValues::InspectEnvironment(args))
+            .await
+    }
+
+    #[tool(
+        description = "Configures lighting, atmosphere, post processing, terrain water, and ambient soundscape settings."
+    )]
+    async fn environment_control(
+        &self,
+        Parameters(args): Parameters<EnvironmentControlRequest>,
+    ) -> Result<CallToolResult, ErrorData> {
+        self.generic_tool_run(ToolArgumentValues::EnvironmentControl(args))
             .await
     }
 


### PR DESCRIPTION
## Summary
- add EnvironmentControl request/response shapes and register the tool handler in the MCP server
- extend the plugin type definitions and add an EnvironmentControl tool module that batches lighting, post-processing, terrain water, and sound edits with validation and change-history rollback
- document the new ambience workflow with usage notes and prompt ideas in the README

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_b_68e6ae685414832f9f3646811caa9597