### PR TITLE
Add automation input and telemetry actions to TestAndPlay tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,6 +374,51 @@ informed while Studio runs. Typical prompts include:
   console logs and highlight failing assertions.”
 - **Emergency stop** – “Issue a `stop` command to halt any running playtest or TestService activity
   and report whether Studio was still in a running state.”
+- **Automated menu navigation** – “Once play mode is running, call `send_input` with key and mouse
+  steps to open the escape menu and click the publish button. Wait between steps so the UI can
+  animate.”
+- **Capture live stats** – “Call `capture_stats` with `includeRunState` and a `Players.LocalPlayer` GUI
+  watch target so I can confirm whether the HUD is visible before proceeding.”
+
+The `send_input` action waits for `RunService:IsRunning()` before dispatching key or mouse events
+through `VirtualInputManager`, so sequences only succeed during active play or playtest sessions. You
+can mix `key`, `mouse_button`, `mouse_move`, and `wait` steps and attach optional `delaySeconds`
+values to pace the automation. Pairing the sequence with telemetry flags lets you capture a
+post-action snapshot of the run state, LocalPlayer position, or GUI visibility. The companion
+`capture_stats` action gathers the same telemetry without emitting input, which is ideal for
+lightweight health checks between runs.
+
+```json
+{
+  "tool": "TestAndPlayControl",
+  "params": {
+    "action": "send_input",
+    "options": {
+      "timeoutSeconds": 45,
+      "inputSequence": [
+        { "kind": "wait", "seconds": 2 },
+        { "kind": "key", "keyCode": "Escape" },
+        { "kind": "mouse_move", "x": 320, "y": 180, "delaySeconds": 0.25 },
+        {
+          "kind": "mouse_button",
+          "button": "MouseButton1",
+          "isDown": true,
+          "x": 320,
+          "y": 180,
+          "delaySeconds": 0.05
+        },
+        { "kind": "mouse_button", "button": "MouseButton1", "isDown": false }
+      ],
+      "watchTargets": ["Players.LocalPlayer.PlayerGui.HUD"],
+      "telemetry": {
+        "includeRunState": true,
+        "includeLocalPlayerPosition": true,
+        "includeGuiVisibility": true
+      }
+    }
+  }
+}
+```
 
 Equivalent JSON payloads can be sent directly from automation:
 

--- a/plugin/src/Tools/TestAndPlayControl.luau
+++ b/plugin/src/Tools/TestAndPlayControl.luau
@@ -4,11 +4,22 @@ local Types = require(Main.Types)
 local HttpService = game:GetService("HttpService")
 local LogService = game:GetService("LogService")
 local RunService = game:GetService("RunService")
+local Players = game:GetService("Players")
+local GuiService = game:GetService("GuiService")
 local StudioService = game:GetService("StudioService")
 local TestService = game:GetService("TestService")
 
+local okVirtualInputManager, VirtualInputManager = pcall(function()
+        return game:GetService("VirtualInputManager")
+end)
+if not okVirtualInputManager then
+        VirtualInputManager = nil
+end
+
 export type TestAndPlayControlArgs = Types.TestAndPlayControlArgs
 export type TestAndPlayControlOptions = Types.TestAndPlayControlOptions
+export type TestAndPlayInputStep = Types.TestAndPlayInputStep
+export type TestAndPlayTelemetryFlags = Types.TestAndPlayTelemetryFlags
 
 local function cloneStringArray(values: { any }?): { string }
         local result = {}
@@ -23,6 +34,166 @@ local function cloneStringArray(values: { any }?): { string }
         end
 
         return result
+end
+
+local function sanitizeDelaySeconds(value: any): number?
+        if typeof(value) ~= "number" then
+                return nil
+        end
+        if value < 0 then
+                return 0
+        end
+        if value == value then
+                return value
+        end
+        return nil
+end
+
+local function sanitizeInputStep(step: any): TestAndPlayInputStep?
+        if type(step) ~= "table" then
+                return nil
+        end
+
+        local kind = step.kind
+        if typeof(kind) ~= "string" then
+                return nil
+        end
+
+        if kind == "wait" then
+                if typeof(step.seconds) ~= "number" then
+                        return nil
+                end
+                local seconds = math.max(0, step.seconds)
+                return {
+                        kind = "wait",
+                        seconds = seconds,
+                }
+        elseif kind == "key" then
+                if typeof(step.keyCode) ~= "string" or step.keyCode == "" then
+                        return nil
+                end
+                local sanitized: TestAndPlayInputStep = {
+                        kind = "key",
+                        keyCode = step.keyCode,
+                }
+                if typeof(step.isDown) == "boolean" then
+                        sanitized.isDown = step.isDown
+                end
+                if typeof(step.isRepeat) == "boolean" then
+                        sanitized.isRepeat = step.isRepeat
+                end
+                if typeof(step.text) == "string" and step.text ~= "" then
+                        sanitized.text = step.text
+                end
+                local delay = sanitizeDelaySeconds(step.delaySeconds)
+                if delay then
+                        sanitized.delaySeconds = delay
+                end
+                return sanitized
+        elseif kind == "mouse_button" then
+                if typeof(step.button) ~= "string" or step.button == "" then
+                        return nil
+                end
+                local sanitized: TestAndPlayInputStep = {
+                        kind = "mouse_button",
+                        button = step.button,
+                }
+                if typeof(step.x) == "number" then
+                        sanitized.x = step.x
+                end
+                if typeof(step.y) == "number" then
+                        sanitized.y = step.y
+                end
+                if typeof(step.isDown) == "boolean" then
+                        sanitized.isDown = step.isDown
+                end
+                if typeof(step.moveMouse) == "boolean" then
+                        sanitized.moveMouse = step.moveMouse
+                end
+                local delay = sanitizeDelaySeconds(step.delaySeconds)
+                if delay then
+                        sanitized.delaySeconds = delay
+                end
+                return sanitized
+        elseif kind == "mouse_move" then
+                local sanitized: TestAndPlayInputStep = {
+                        kind = "mouse_move",
+                }
+                if typeof(step.x) == "number" then
+                        sanitized.x = step.x
+                end
+                if typeof(step.y) == "number" then
+                        sanitized.y = step.y
+                end
+                if typeof(step.deltaX) == "number" then
+                        sanitized.deltaX = step.deltaX
+                end
+                if typeof(step.deltaY) == "number" then
+                        sanitized.deltaY = step.deltaY
+                end
+                local delay = sanitizeDelaySeconds(step.delaySeconds)
+                if delay then
+                        sanitized.delaySeconds = delay
+                end
+                if sanitized.x == nil then
+                        sanitized.x = 0
+                end
+                if sanitized.y == nil then
+                        sanitized.y = 0
+                end
+                if sanitized.deltaX == nil then
+                        sanitized.deltaX = 0
+                end
+                if sanitized.deltaY == nil then
+                        sanitized.deltaY = 0
+                end
+                return sanitized
+        end
+
+        return nil
+end
+
+local function sanitizeInputSequence(sequence: { any }?): { TestAndPlayInputStep }?
+        if type(sequence) ~= "table" then
+                return nil
+        end
+
+        local sanitized = {}
+        for _, step in sequence do
+                local sanitizedStep = sanitizeInputStep(step)
+                if sanitizedStep then
+                        table.insert(sanitized, sanitizedStep)
+                end
+        end
+
+        if #sanitized == 0 then
+                return nil
+        end
+
+        return sanitized
+end
+
+local function sanitizeTelemetryFlags(telemetry: any): TestAndPlayTelemetryFlags?
+        if type(telemetry) ~= "table" then
+                return nil
+        end
+
+        local sanitized: TestAndPlayTelemetryFlags = {}
+        if typeof(telemetry.includeRunState) == "boolean" then
+                sanitized.includeRunState = telemetry.includeRunState
+        end
+        if typeof(telemetry.includeLocalPlayerPosition) == "boolean" then
+                sanitized.includeLocalPlayerPosition = telemetry.includeLocalPlayerPosition
+        end
+        if typeof(telemetry.includeGuiVisibility) == "boolean" then
+                sanitized.includeGuiVisibility = telemetry.includeGuiVisibility
+        end
+
+        if next(sanitized) == nil then
+                return nil
+        end
+
+        return sanitized
 end
 
 local function sanitizeOptions(options: TestAndPlayControlOptions?): TestAndPlayControlOptions?
@@ -47,6 +218,18 @@ local function sanitizeOptions(options: TestAndPlayControlOptions?): TestAndPlay
         if typeof(options.includeLogHistory) == "boolean" then
                 sanitized.includeLogHistory = options.includeLogHistory
         end
+        local inputSequence = sanitizeInputSequence(options.inputSequence)
+        if inputSequence then
+                sanitized.inputSequence = inputSequence
+        end
+        local watchTargets = cloneStringArray(options.watchTargets)
+        if #watchTargets > 0 then
+                sanitized.watchTargets = watchTargets
+        end
+        local telemetry = sanitizeTelemetryFlags(options.telemetry)
+        if telemetry then
+                sanitized.telemetry = telemetry
+        end
 
         if next(sanitized) == nil then
                 return nil
@@ -66,12 +249,28 @@ local function findUnknownOptions(options: TestAndPlayControlOptions?): { string
                 testNames = true,
                 runAsync = true,
                 includeLogHistory = true,
+                inputSequence = true,
+                watchTargets = true,
+                telemetry = true,
         }
 
         local unknown = {}
         for key, _ in options do
                 if typeof(key) == "string" and not recognised[key] then
                         table.insert(unknown, key)
+                end
+        end
+
+        if type(options.telemetry) == "table" then
+                local recognisedTelemetry = {
+                        includeRunState = true,
+                        includeLocalPlayerPosition = true,
+                        includeGuiVisibility = true,
+                }
+                for key, _ in options.telemetry do
+                        if typeof(key) == "string" and not recognisedTelemetry[key] then
+                                table.insert(unknown, "telemetry." .. key)
+                        end
                 end
         end
 
@@ -259,6 +458,429 @@ local function readRunServiceState(): (boolean, string?)
                 return state == true, nil
         end
         return false, tostring(state)
+end
+
+local function waitForRunLoop(timeoutSeconds: number): (boolean, string?, number)
+        local timeout = math.max(0.1, timeoutSeconds)
+        local startClock = os.clock()
+        local deadline = startClock + timeout
+        local lastError: string? = nil
+
+        while os.clock() < deadline do
+                local running, err = readRunServiceState()
+                if err then
+                        lastError = err
+                end
+                if running then
+                        return true, nil, os.clock() - startClock
+                end
+                task.wait(0.1)
+        end
+
+        local running, err = readRunServiceState()
+        if running then
+                return true, nil, os.clock() - startClock
+        end
+        if err then
+                lastError = err
+        end
+        return false, lastError, os.clock() - startClock
+end
+
+local function captureLocalPlayerPosition(): ({ x: number, y: number, z: number }?, string?)
+        local player = Players.LocalPlayer
+        if player == nil then
+                return nil, "Players.LocalPlayer is nil"
+        end
+
+        local character = player.Character
+        if character == nil then
+                return nil, "LocalPlayer.Character is unavailable"
+        end
+
+        local humanoidRoot = character:FindFirstChild("HumanoidRootPart")
+        local basePart = if humanoidRoot and humanoidRoot:IsA("BasePart")
+                then humanoidRoot
+                else nil
+
+        if basePart == nil then
+                local primary = character.PrimaryPart
+                if primary and primary:IsA("BasePart") then
+                        basePart = primary
+                end
+        end
+
+        if basePart == nil then
+                return nil, "HumanoidRootPart or PrimaryPart is missing"
+        end
+
+        local position = basePart.Position
+        return {
+                x = position.X,
+                y = position.Y,
+                z = position.Z,
+        }, nil
+end
+
+local function splitWatchTargetPath(target: string): { string }
+        local segments = {}
+        for segment in string.gmatch(target, "[^%.]+") do
+                table.insert(segments, segment)
+        end
+        return segments
+end
+
+local function resolveWatchTarget(target: string): (Instance?, string?, string?)
+        if typeof(target) ~= "string" or target == "" then
+                return nil, nil, "Target must be a non-empty string"
+        end
+
+        local segments = splitWatchTargetPath(target)
+        if #segments == 0 then
+                return nil, nil, "Unable to parse watch target"
+        end
+
+        local current: Instance? = game
+        for index, segment in segments do
+                local isLast = index == #segments
+                if segment == "game" or segment == "Game" then
+                        current = game
+                        if isLast then
+                                return current, nil, nil
+                        end
+                        continue
+                end
+
+                local nextInstance: Instance? = nil
+                if current == game then
+                        local okService, service = pcall(function()
+                                return game:GetService(segment)
+                        end)
+                        if okService then
+                                nextInstance = service
+                        end
+                end
+
+                if nextInstance == nil and current then
+                        nextInstance = current:FindFirstChild(segment)
+                end
+
+                if nextInstance == nil and current then
+                        local ok, value = pcall(function()
+                                return (current :: any)[segment]
+                        end)
+                        if ok and typeof(value) == "Instance" then
+                                nextInstance = value
+                        elseif ok and isLast then
+                                return current, segment, nil
+                        end
+                end
+
+                if nextInstance then
+                        current = nextInstance
+                        if isLast then
+                                return current, nil, nil
+                        end
+                else
+                        if isLast then
+                                return current, segment, nil
+                        end
+                        return nil, nil, string.format("Unable to resolve segment '%s'", segment)
+                end
+        end
+
+        return current, nil, nil
+end
+
+local function captureWatchTargetValue(target: string)
+        local instance, propertyName, resolveError = resolveWatchTarget(target)
+        if resolveError then
+                return nil, nil, resolveError
+        end
+        if instance == nil then
+                return nil, nil, string.format("Watch target '%s' could not be resolved", target)
+        end
+
+        local properties = {}
+        if propertyName then
+                        table.insert(properties, propertyName)
+        end
+        table.insert(properties, "Visible")
+        table.insert(properties, "Enabled")
+
+        for _, property in properties do
+                local ok, value = pcall(function()
+                        return (instance :: any)[property]
+                end)
+                if ok and value ~= nil then
+                        return value, property, nil
+                end
+        end
+
+        return nil, nil, string.format("Unable to read a visibility property from '%s'", target)
+end
+
+local function captureGuiVisibility(targets: { string }, warnings: { any }): { [string]: any }
+        local visibility = {}
+        for _, target in targets do
+                local value, property, errorMessage = captureWatchTargetValue(target)
+                if errorMessage then
+                        table.insert(warnings, string.format("%s", errorMessage))
+                elseif value ~= nil then
+                        visibility[target] = {
+                                property = property,
+                                value = sanitizeForJson(value, 1),
+                        }
+                end
+        end
+
+        return visibility
+end
+
+local function collectTelemetrySnapshot(
+        options: TestAndPlayControlOptions?,
+        result: { [string]: any }
+): { [string]: any }?
+        if type(options) ~= "table" or type(options.telemetry) ~= "table" then
+                return nil
+        end
+
+        local telemetry = {}
+        local flags = options.telemetry :: TestAndPlayTelemetryFlags
+
+        if flags.includeRunState == true then
+                local runState = {}
+                local running, runError = readRunServiceState()
+                runState.isRunning = running
+                if runError then
+                        table.insert(result.warnings, "RunService:IsRunning failed: " .. runError)
+                end
+                local ok, mode = pcall(function()
+                        return RunService:IsRunMode()
+                end)
+                if ok then
+                        runState.isRunMode = mode and true or false
+                else
+                        table.insert(result.warnings, "RunService:IsRunMode failed: " .. tostring(mode))
+                end
+                telemetry.runState = runState
+        end
+
+        if flags.includeLocalPlayerPosition == true then
+                local position, positionError = captureLocalPlayerPosition()
+                if position then
+                        telemetry.localPlayerPosition = position
+                elseif positionError then
+                        table.insert(result.warnings, "LocalPlayer position unavailable: " .. positionError)
+                end
+        end
+
+        if flags.includeGuiVisibility == true then
+                local watchTargets = options.watchTargets
+                if type(watchTargets) == "table" and #watchTargets > 0 then
+                        local visibility = captureGuiVisibility(watchTargets, result.warnings)
+                        if next(visibility) ~= nil then
+                                telemetry.guiVisibility = visibility
+                        end
+                else
+                        table.insert(
+                                result.warnings,
+                                "No watchTargets provided for GUI visibility telemetry"
+                        )
+                end
+        end
+
+        if next(telemetry) == nil then
+                return nil
+        end
+
+        return telemetry
+end
+
+local function executeInputSequence(
+        sequence: { TestAndPlayInputStep },
+        result: { [string]: any }
+): { [string]: any }
+        local reports = {}
+        if type(sequence) ~= "table" then
+                return reports
+        end
+
+        for index, step in sequence do
+                if typeof(step) ~= "table" then
+                        continue
+                end
+
+                if typeof((step :: any).delaySeconds) == "number" then
+                        task.wait(math.max(0, (step :: any).delaySeconds))
+                end
+
+                if step.kind == "wait" then
+                        local waitSeconds = math.max(0, step.seconds or 0)
+                        if waitSeconds > 0 then
+                                task.wait(waitSeconds)
+                        end
+                        table.insert(reports, {
+                                index = index,
+                                kind = step.kind,
+                                status = "waited",
+                                seconds = waitSeconds,
+                        })
+                elseif step.kind == "key" then
+                        local keyCodeEnum = Enum.KeyCode[step.keyCode]
+                        if not keyCodeEnum then
+                                table.insert(result.warnings, string.format(
+                                        "Unknown keyCode '%s' for step %d",
+                                        tostring(step.keyCode),
+                                        index
+                                ))
+                                table.insert(reports, {
+                                        index = index,
+                                        kind = step.kind,
+                                        status = "skipped",
+                                        reason = "unknown_key_code",
+                                })
+                        elseif not VirtualInputManager then
+                                table.insert(result.warnings, "VirtualInputManager is unavailable")
+                                table.insert(reports, {
+                                        index = index,
+                                        kind = step.kind,
+                                        status = "skipped",
+                                        reason = "virtual_input_unavailable",
+                                })
+                        else
+                                local isDown = if typeof(step.isDown) == "boolean" then step.isDown else true
+                                local isRepeat = step.isRepeat == true
+                                local text = if typeof(step.text) == "string" then step.text else nil
+                                local ok, err = pcall(function()
+                                        VirtualInputManager:SendKeyEvent(isDown, keyCodeEnum, isRepeat, text)
+                                end)
+                                if ok then
+                                        table.insert(reports, {
+                                                index = index,
+                                                kind = step.kind,
+                                                status = "sent",
+                                                isDown = isDown,
+                                                isRepeat = isRepeat,
+                                        })
+                                else
+                                        local message = tostring(err)
+                                        table.insert(result.warnings, string.format(
+                                                "SendKeyEvent failed at step %d: %s",
+                                                index,
+                                                message
+                                        ))
+                                        table.insert(reports, {
+                                                index = index,
+                                                kind = step.kind,
+                                                status = "error",
+                                                message = message,
+                                        })
+                                end
+                        end
+                elseif step.kind == "mouse_button" then
+                        local userInput = Enum.UserInputType[step.button]
+                        if not userInput then
+                                table.insert(result.warnings, string.format(
+                                        "Unknown mouse button '%s' for step %d",
+                                        tostring(step.button),
+                                        index
+                                ))
+                                table.insert(reports, {
+                                        index = index,
+                                        kind = step.kind,
+                                        status = "skipped",
+                                        reason = "unknown_button",
+                                })
+                        elseif not VirtualInputManager then
+                                table.insert(result.warnings, "VirtualInputManager is unavailable")
+                                table.insert(reports, {
+                                        index = index,
+                                        kind = step.kind,
+                                        status = "skipped",
+                                        reason = "virtual_input_unavailable",
+                                })
+                        else
+                                local x = typeof(step.x) == "number" and step.x or 0
+                                local y = typeof(step.y) == "number" and step.y or 0
+                                local isDown = if typeof(step.isDown) == "boolean" then step.isDown else true
+                                local moveMouse = step.moveMouse == true
+                                local ok, err = pcall(function()
+                                        VirtualInputManager:SendMouseButtonEvent(x, y, userInput, isDown, moveMouse)
+                                end)
+                                if ok then
+                                        table.insert(reports, {
+                                                index = index,
+                                                kind = step.kind,
+                                                status = "sent",
+                                                isDown = isDown,
+                                                button = step.button,
+                                        })
+                                else
+                                        local message = tostring(err)
+                                        table.insert(result.warnings, string.format(
+                                                "SendMouseButtonEvent failed at step %d: %s",
+                                                index,
+                                                message
+                                        ))
+                                        table.insert(reports, {
+                                                index = index,
+                                                kind = step.kind,
+                                                status = "error",
+                                                message = message,
+                                        })
+                                end
+                        end
+                elseif step.kind == "mouse_move" then
+                        if not VirtualInputManager then
+                                table.insert(result.warnings, "VirtualInputManager is unavailable")
+                                table.insert(reports, {
+                                        index = index,
+                                        kind = step.kind,
+                                        status = "skipped",
+                                        reason = "virtual_input_unavailable",
+                                })
+                        else
+                                local x = typeof(step.x) == "number" and step.x or 0
+                                local y = typeof(step.y) == "number" and step.y or 0
+                                local deltaX = typeof(step.deltaX) == "number" and step.deltaX or 0
+                                local deltaY = typeof(step.deltaY) == "number" and step.deltaY or 0
+                                local ok, err = pcall(function()
+                                        VirtualInputManager:SendMouseMoveEvent(x, y, deltaX, deltaY)
+                                end)
+                                if ok then
+                                        table.insert(reports, {
+                                                index = index,
+                                                kind = step.kind,
+                                                status = "sent",
+                                                x = x,
+                                                y = y,
+                                        })
+                                else
+                                        local message = tostring(err)
+                                        table.insert(result.warnings, string.format(
+                                                "SendMouseMoveEvent failed at step %d: %s",
+                                                index,
+                                                message
+                                        ))
+                                        table.insert(reports, {
+                                                index = index,
+                                                kind = step.kind,
+                                                status = "error",
+                                                message = message,
+                                        })
+                                end
+                        end
+                else
+                        table.insert(result.warnings, string.format(
+                                "Unsupported input step kind '%s' at index %d",
+                                tostring(step.kind),
+                                index
+                        ))
+                end
+        end
+
+        return reports
 end
 
 local function tryStudioMethods(methods: { string }, ...): (boolean, string?, string?)
@@ -749,6 +1371,128 @@ local function handleStop(
         return HttpService:JSONEncode(result)
 end
 
+local function handleSendInput(
+        options: TestAndPlayControlOptions?,
+        unknownOptions: { string }?
+): string
+        local result = createBaseResult("send_input", options)
+        local includeLogs = shouldIncludeLogs(options)
+        local collector = createLogCollector()
+        local chunkIndex = 0
+
+        if collector.error then
+                table.insert(result.warnings, "Unable to subscribe to log output: " .. collector.error)
+        end
+        if unknownOptions then
+                table.insert(result.warnings, "Ignoring unsupported option keys: " .. table.concat(unknownOptions, ", "))
+        end
+
+        if not VirtualInputManager then
+                result.status = "error"
+                table.insert(result.errors, {
+                        stage = "preflight",
+                        message = "VirtualInputManager service is unavailable in this session",
+                })
+                pushStatusUpdate(result, result.status)
+                finalizeResult(result, collector, chunkIndex, includeLogs)
+                return HttpService:JSONEncode(result)
+        end
+
+        local sequence = nil
+        if options and type(options.inputSequence) == "table" then
+                sequence = options.inputSequence
+        end
+        if not sequence or #sequence == 0 then
+                result.status = "skipped"
+                table.insert(
+                        result.warnings,
+                        "No inputSequence steps were provided; nothing was sent to the session"
+                )
+                pushStatusUpdate(result, result.status)
+                finalizeResult(result, collector, chunkIndex, includeLogs)
+                return HttpService:JSONEncode(result)
+        end
+
+        local timeout = if options and typeof(options.timeoutSeconds) == "number"
+                then options.timeoutSeconds
+                else 30
+        local running, runError, waitedSeconds = waitForRunLoop(timeout)
+        result.waitedForRunSeconds = waitedSeconds
+        if not running then
+                result.status = "not_running"
+                local message = "RunService was not running; input sequence aborted"
+                if runError then
+                        message ..= ": " .. runError
+                end
+                table.insert(result.errors, {
+                        stage = "preflight",
+                        message = message,
+                })
+                pushStatusUpdate(result, result.status)
+                finalizeResult(result, collector, chunkIndex, includeLogs)
+                return HttpService:JSONEncode(result)
+        end
+
+        result.status = "sending"
+        pushStatusUpdate(result, result.status)
+
+        local reports = executeInputSequence(sequence, result)
+        result.inputReport = reports
+        result.sequenceLength = #sequence
+
+        local telemetry = collectTelemetrySnapshot(options, result)
+        if telemetry then
+                result.telemetry = telemetry
+        end
+
+        local isRunning, finalRunError = readRunServiceState()
+        result.isRunning = isRunning
+        if finalRunError then
+                table.insert(result.warnings, "Final RunService:IsRunning check failed: " .. finalRunError)
+        end
+
+        result.status = "completed"
+        pushStatusUpdate(result, result.status)
+
+        finalizeResult(result, collector, chunkIndex, includeLogs)
+        return HttpService:JSONEncode(result)
+end
+
+local function handleCaptureStats(
+        options: TestAndPlayControlOptions?,
+        unknownOptions: { string }?
+): string
+        local result = createBaseResult("capture_stats", options)
+        if unknownOptions then
+                table.insert(result.warnings, "Ignoring unsupported option keys: " .. table.concat(unknownOptions, ", "))
+        end
+
+        result.status = "collecting"
+        pushStatusUpdate(result, result.status)
+
+        local telemetry = collectTelemetrySnapshot(options, result)
+        if telemetry then
+                result.telemetry = telemetry
+        else
+                table.insert(
+                        result.warnings,
+                        "No telemetry flags were provided; returning run state details only"
+                )
+        end
+
+        local isRunning, runError = readRunServiceState()
+        result.isRunning = isRunning
+        if runError then
+                table.insert(result.warnings, "RunService:IsRunning failed: " .. runError)
+        end
+
+        result.status = "completed"
+        pushStatusUpdate(result, result.status)
+
+        finalizeResult(result, nil, 0, shouldIncludeLogs(options))
+        return HttpService:JSONEncode(result)
+end
+
 local function handleTestAndPlayControl(args: Types.ToolArgs): string?
         if args.tool ~= "TestAndPlayControl" then
                 return nil
@@ -780,6 +1524,10 @@ local function handleTestAndPlayControl(args: Types.ToolArgs): string?
                 return handleRunTests(options, unknownOptions)
         elseif action == "stop" then
                 return handleStop(options, unknownOptions)
+        elseif action == "send_input" then
+                return handleSendInput(options, unknownOptions)
+        elseif action == "capture_stats" then
+                return handleCaptureStats(options, unknownOptions)
         end
 
         error("Unsupported TestAndPlayControl action: " .. tostring(action))

--- a/plugin/src/Types.luau
+++ b/plugin/src/Types.luau
@@ -703,7 +703,58 @@ export type EditorSessionControlToolArgs = {
         params: EditorSessionControlArgs,
 }
 
-export type TestAndPlayAction = "play_solo" | "stop" | "run_tests" | "run_playtest"
+export type TestAndPlayAction =
+        "play_solo"
+        | "stop"
+        | "run_tests"
+        | "run_playtest"
+        | "send_input"
+        | "capture_stats"
+
+export type TestAndPlayInputWaitStep = {
+        kind: "wait",
+        seconds: number,
+}
+
+export type TestAndPlayInputKeyStep = {
+        kind: "key",
+        keyCode: string,
+        isDown: boolean?,
+        isRepeat: boolean?,
+        text: string?,
+        delaySeconds: number?,
+}
+
+export type TestAndPlayInputMouseButtonStep = {
+        kind: "mouse_button",
+        x: number?,
+        y: number?,
+        button: string,
+        isDown: boolean?,
+        moveMouse: boolean?,
+        delaySeconds: number?,
+}
+
+export type TestAndPlayInputMouseMoveStep = {
+        kind: "mouse_move",
+        x: number?,
+        y: number?,
+        deltaX: number?,
+        deltaY: number?,
+        delaySeconds: number?,
+}
+
+export type TestAndPlayInputStep =
+        TestAndPlayInputWaitStep
+        | TestAndPlayInputKeyStep
+        | TestAndPlayInputMouseButtonStep
+        | TestAndPlayInputMouseMoveStep
+
+export type TestAndPlayTelemetryFlags = {
+        includeRunState: boolean?,
+        includeLocalPlayerPosition: boolean?,
+        includeGuiVisibility: boolean?,
+}
 
 export type TestAndPlayControlOptions = {
         timeoutSeconds: number?,
@@ -711,6 +762,9 @@ export type TestAndPlayControlOptions = {
         testNames: { string }?,
         runAsync: boolean?,
         includeLogHistory: boolean?,
+        inputSequence: { TestAndPlayInputStep }?,
+        watchTargets: { string }?,
+        telemetry: TestAndPlayTelemetryFlags?,
 }
 
 export type TestAndPlayControlArgs = {


### PR DESCRIPTION
## Summary
- extend TestAndPlayControl schemas to advertise new `send_input` and `capture_stats` actions with input sequences and telemetry options
- update the Studio plugin types and control logic to sanitize input steps, wait for running play sessions, dispatch VirtualInputManager events, and capture telemetry diagnostics
- document example usage for automated input sequences and telemetry capture in the README

## Testing
- cargo check

------
https://chatgpt.com/codex/tasks/task_b_68e6c086910c832fb8c84706906410bd