### PR TITLE
Add interactive studio installer subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -458,6 +458,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -580,6 +593,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "dialoguer"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "658bce805d770f407bc62102fca7c2c64ceef2fbcb2b8bd19d2765ce093980de"
+dependencies = [
+ "console",
+ "shell-words",
+ "tempfile",
+ "thiserror 1.0.69",
+ "zeroize",
+]
+
+[[package]]
 name = "dirs"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -668,6 +694,12 @@ dependencies = [
  "vswhom",
  "winreg 0.10.1",
 ]
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "encoding_rs"
@@ -2313,6 +2345,7 @@ dependencies = [
  "clap 4.5.37",
  "color-eyre",
  "core-foundation 0.10.0",
+ "dialoguer",
  "native-dialog",
  "reqwest 0.12.15",
  "rmcp",
@@ -3017,6 +3050,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shell-words"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3449,6 +3488,12 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ reqwest = { version = "0.12", features = ["json"] }
 color-eyre = "0.6"
 clap = { version = "4.5.37", features = ["derive"] }
 roblox_install = "1.0.0"
+dialoguer = "0.11"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 native-dialog = "0.8.8"


### PR DESCRIPTION
## Summary
- replace the legacy `--stdio` flag with clap subcommands including a `studio-install` entry point and legacy flag handling
- factor the installer into reusable helpers and add LM Studio configuration support
- add an interactive installer loop driven by dialoguer for plugin and MCP client setup

## Testing
- cargo check

------
https://chatgpt.com/codex/tasks/task_b_68e7656a4f34832f8f88dec82b0621ac