### PR TITLE
Handle missing HOME in Claude config lookup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2354,6 +2354,7 @@ dependencies = [
  "security-translocate",
  "serde",
  "serde_json",
+ "temp-env",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -3216,6 +3217,15 @@ checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
  "core-foundation-sys",
  "libc",
+]
+
+[[package]]
+name = "temp-env"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96374855068f47402c3121c6eed88d29cb1de8f3ab27090e273e420bdabcf050"
+dependencies = [
+ "parking_lot",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,9 @@ core-foundation = "0.10.0"
 [build-dependencies]
 rojo = "7.4.4"
 
+[dev-dependencies]
+temp-env = "0.3"
+
 [package.metadata.bundle]
 name = "RobloxStudioMCP"
 description = "Model Context Protocol server for Roblox Studio"


### PR DESCRIPTION
## Summary
- return a descriptive error from `get_claude_config` when `HOME` is missing on macOS
- add a regression test that clears `HOME` to ensure the function no longer panics
- pull in `temp-env` as a dev-dependency to manipulate environment variables during tests

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_b_68e8a6fcd2d4832fabc1fa573766725f