### PR TITLE
Handle axum server errors gracefully

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2358,6 +2358,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "tracing-test",
  "uuid",
 ]
 
@@ -3485,6 +3486,27 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
+]
+
+[[package]]
+name = "tracing-test"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "557b891436fe0d5e0e363427fc7f217abf9ccd510d5136549847bdcbcd011d68"
+dependencies = [
+ "tracing-core",
+ "tracing-subscriber",
+ "tracing-test-macro",
+]
+
+[[package]]
+name = "tracing-test-macro"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04659ddb06c87d233c566112c1c9c5b9e98256d9af50ec3bc9c8327f873a7568"
+dependencies = [
+ "quote 1.0.40",
+ "syn 2.0.101",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ rojo = "7.4.4"
 
 [dev-dependencies]
 temp-env = "0.3"
+tracing-test = "0.2"
 
 [package.metadata.bundle]
 name = "RobloxStudioMCP"


### PR DESCRIPTION
## Summary
- propagate axum HTTP server failures by logging, signalling shutdown, and returning errors
- extract shared shutdown signalling helper and reuse it for both listener and proxy modes
- add a regression test to confirm the HTTP server task logs and triggers shutdown on failure
- add tracing-test as a dev dependency for log assertions

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_b_68e9f604254c832f974ee0b564e79cba